### PR TITLE
added unit tests for parsing HTTP request 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ HTTP server for your application so you easy can plug your RPG code into a servi
 infrastructure or make simple web applications without the need of any third party 
 webserver products.
 
-Basically it is a HTTP application server you can bind into your own ILE RPG projects, 
-to give you a easy deploy mechanism, that fits into DevOps and microservices alike 
-environments.
+Basically it is a HTTP application server you can bind into your own ILE RPG 
+projects, to give you a easy deploy mechanism, that fits into DevOps and 
+microservices alike environments.
 
 The self contained web application server makes it so much easier to develop 
 web application. 
@@ -91,20 +91,20 @@ What you need before you start:
 * IBM i 7.3 TR3 ( obove or alike)
 * git and gmake ( 5733OPS or YUM)
 * ILE C 
-* ILE RPG compiler.
+* ILE RPG compiler
 
 
 From a IBM i menu prompt start the SSH deamon:`===> STRTCPSVR *SSHD`
-Or start ssh from win/mac
+Or start ssh from win/mac/linux
 
 ```
 mkdir /prj
 cd /prj 
-git -c http.sslVerify=false clone https://github.com/NielsLiisberg/ILEastic.git
+git -c http.sslVerify=false clone https://github.com/sitemule/ILEastic.git
 cd ILEastic
-gmake 
+make 
 cd test 
-gmake
+make
 ```
 
 # Test it:
@@ -121,14 +121,19 @@ Now test it in a browser:
 * http://myibmi:44998
 * http://myibmi:44999
 
-A simple hello and list with a counter. Please note that the job requires `ALWMLTTHD(*YES)`
+A simple hello and list with a counter. Please note that the job requires 
+`ALWMLTTHD(*YES)`.
 
 
 # Develop
 You compile the project with gmake, and I have also included a setup folder for
-vsCode so you can compile any changes with `Ctrl-shift-B` You need however to 
+vsCode so you can compile any changes with `Ctrl-Shift-B` You need however to 
 change .vsCode/task.json file to point to your IBM i address. The compile feature 
-requires that you have SSH stated: `STRTCPSVR *SSHD` 
+requires that you have SSH started: `STRTCPSVR *SSHD` 
+
+# Unit Tests
+For executing the unit tests located in the folder _unittests_ you need to 
+previously install either [iRPGUnit][iru] or [RPGUnit][ru].
 
 # Moving on
 In this first commit we have only implemented the `il_listen` and `il_responseWrite`, 
@@ -144,4 +149,7 @@ node.js code :) so obvously it was a bad name. Thanks for the feedback pointing
 me into a better direction.
 
 Happy ILEastic coding
+
+[iru]: https://irpgunit.sourceforge.net
+[ru]: https://rpgunit.sourceforge.net
 

--- a/headers/ileastic.rpgle
+++ b/headers/ileastic.rpgle
@@ -62,7 +62,9 @@ dcl-ds il_request qualified template;
     headers        likeds(il_varchar);
     content        likeds(il_varchar);
     contentType    varchar(256);
+    contentLength  uns(20);
     completeHeader likeds(il_varchar);
+    headerList     pointer;
 end-ds;
 
 ///

--- a/makefile
+++ b/makefile
@@ -1,23 +1,31 @@
-#-----------------------------------------------------------
+#-------------------------------------------------------------------------------
 # User-defined part start
 #
 
 # BIN_LIB is the destination library for the service program.
-# the rpg modules and the binder source file are also created in BIN_LIB.
-# binder source file and rpg module can be remove with the clean step (make clean)
+# The rpg modules and the binder source file are also created in BIN_LIB.
+# Binder source file and rpg module can be remove with the clean step 
+# (make clean).
 BIN_LIB=ILEASTIC
 
-# to this folder the header files (prototypes) are copied in the install step
+#
+# The folder where the copy books for ILEastic will be copied to with the 
+# install step (make install).
+#
+USRINCDIR=/usr/local/include
+
+#
+# User-defined part end
+#-------------------------------------------------------------------------------
+
+
+# system and application include folder
 INCLUDE='/QIBM/include' 'headers/'
 
 # CCFLAGS = C compiler parameter
 CCFLAGS=OPTIMIZE(10) ENUM(*INT) TERASPACE(*YES) STGMDL(*INHERIT) SYSIFCOPT(*IFSIO) INCDIR($(INCLUDE)) DBGVIEW(*ALL)
 CCFLAGS2=OPTION(*STDLOGMSG) OUTPUT(*NONE) OPTIMIZE(10) ENUM(*INT) TERASPACE(*YES) STGMDL(*INHERIT) SYSIFCOPT(*IFSIO) DBGVIEW(*ALL) INCDIR($(INCLUDE)) 
 
-
-#
-# User-defined part end
-#-----------------------------------------------------------
 
 all: env compile bind 
 
@@ -42,12 +50,25 @@ compile:
 bind:
 	-system -q "CRTSRCPF FILE($(BIN_LIB)/QSRVSRC) RCDLEN(112)"
 	system "CPYFRMSTMF FROMSTMF('headers/ileastic.bnd') TOMBR('/QSYS.lib/$(BIN_LIB).lib/QSRVSRC.file/ILEASTIC.mbr') MBROPT(*replace)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/ILEASTIC) OBJTYPE(*SRVPGM)"
 	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILEASTIC) MODULE($(BIN_LIB)/*ALL) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - programable applicationserver for ILE')"
 
 clean:
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/STREAM) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/ILEASTIC) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/VARCHAR) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/API) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/SNDPGMMSG) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/STRUTIL) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/E2AA2E) OBJTYPE(*MODULE)"
+	-system -q "DLTOBJ OBJ($(BIN_LIB)/XLATE) OBJTYPE(*MODULE)"
 	-system -q "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)"
 
 # For vsCode 
 current: env
-
 	system "CRTCMOD MODULE($(BIN_LIB)/$(SRC)) SRCSTMF('src/$(SRC).c') $(CCFLAGS2) "
+
+install:
+	-mkdir $(INCLUDE)/ILEastic
+	cp headers/ileastic.rpgle $(USRINCDIR)/ILEastic/
+

--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -185,6 +185,9 @@ static void parseHeaders (PREQUEST pRequest)
     while (begin < headend) {
         for (;*begin == 0x20; begin ++); // Skip blank(s)
         end  = memmem(begin, headend - begin , eol , 2); // Find end of line
+        if (end == null) { // end of line not found => end of headers
+          end = headend;
+        }
         split= memchr(begin, 0x3A, end - begin ); // Split at the : colon
         if (split == null) break;
 
@@ -199,7 +202,7 @@ static void parseHeaders (PREQUEST pRequest)
 
         // Next iteration
         begin = end + 2; // After the eol mark
-        hIx ++;
+        hIx++;
     }
     // Store the header list in the request structure
     pRequest->headerList = malloc((hIx +1) * sizeof(HEADERLIST)); // plus room for the termination zero
@@ -236,7 +239,7 @@ PUCHAR getHeaderValue(PUCHAR  value, PHEADERLIST headerList ,  PUCHAR key)
    Parse this: 
    GET / HTTP/1.1██Host: dksrv133:44001██Con
    --------------------------------------------------------------------------- */
-static BOOL lookForHeaders ( PREQUEST pRequest, PUCHAR buf , ULONG bufLen)
+BOOL lookForHeaders ( PREQUEST pRequest, PUCHAR buf , ULONG bufLen)
 {
 
     ULONG beforeHeadersLen;

--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -1,0 +1,37 @@
+#
+# Build script for ILEastic Unit Tests
+#
+
+
+#-------------------------------------------------------------------------------
+# User-defined part start
+#
+
+# BIN_LIB is the destination library for the unit tests.
+BIN_LIB=ILEASTIC
+
+# This folder contains the ASSERT copybook of the unit testing framework.
+RUINCDIR=/usr/local/include/irpgunit
+
+# This library contains the ILEASTIC modules.
+ILEASTIC_LIB=ILEASTIC
+
+#
+# User-defined part end
+#-------------------------------------------------------------------------------
+
+
+OBJECTS = REQUEST
+
+all: clean compile
+
+compile: $(OBJECTS)
+
+REQUEST:
+	system "CRTRPGMOD MODULE($(BIN_LIB)/REQUEST) SRCSTMF('request.rpgle') INCDIR('$(RUINCDIR)') dbgview(*source) stgmdl(*teraspace)"
+	system "CRTSRVPGM $(BIN_LIB)/REQUEST MODULE(($(BIN_LIB)/REQUEST) ($(ILEASTIC_LIB)/*ALL)) STGMDL(*TERASPACE) BNDSRVPGM(ASSERT) EXPORT(*ALL) OPTION(*DUPPROC)"
+
+clean:
+	-system "DLTMOD $(BIN_LIB)/REQUEST"
+	-system "DLTSRVPGM $(BIN_LIB)/REQUEST"
+

--- a/unittests/README.md
+++ b/unittests/README.md
@@ -1,0 +1,31 @@
+# ILEastic Unit Tests
+
+For executing the unit tests located in the folder _unittests_ you need to 
+previously install either [iRPGUnit][iru] or [RPGUnit][ru].
+
+You can compile the unit tests with the make tool.
+
+    make
+
+The unit tests need access to the ASSERT copy book from the iRPGUNIT or RPGUNIT.
+You need to pass this as a parameter to the make command:
+
+    make RUINCDIR=/usr/local/include/irpgunit
+
+By default the unit tests are placed in the ILEASTIC library. You can change
+that by passing your custom library to the BIN_LIB parameter like this:
+
+    make BIN_LIB=ILEASTICUT
+
+The unit tests need the ILEASTIC modules. By default they are expected in the
+library ILEASTIC. You can change the by passing that to the parameter
+ILEASTIC_LIB like this:
+
+    make BIN_LIB=ILEASTICUT ILEASTIC_LIB=MICROSERVR
+
+Note: It is assumed that the ASSERT service program of the unit testing
+      framework is in the library list.
+
+[iru]: https://irpgunit.sourceforge.net
+[ru]: https://rpgunit.sourceforge.net
+

--- a/unittests/request.rpgle
+++ b/unittests/request.rpgle
@@ -1,0 +1,182 @@
+**FREE
+
+///
+// Request Test
+//
+// The parsing of the HTTP request and returning of the parts of the request
+// will be tested here.
+//
+// @author Mihael Schmidt
+// @date   20.09.2018
+///
+
+
+ctl-opt nomain;
+
+
+//
+// Includes
+//
+/include '../headers/ileastic.rpgle'
+/include assert
+
+
+//
+// Prototypes
+//
+dcl-pr setup end-pr;
+dcl-pr teardown end-pr;
+dcl-pr test_parseSimpleRequest end-pr;
+dcl-pr test_parseGetMultipleHeader end-pr;
+dcl-pr test_headerCaseInsensitivity end-pr;
+dcl-pr test_headerNotExist end-pr;
+dcl-pr test_headerEmptyHeaderValue end-pr;
+
+// BOOL lookForHeaders ( PREQUEST pRequest, PUCHAR buf , ULONG bufLen)
+dcl-pr lookForHeaders extproc(*CWIDEN:*dclcase);
+  request pointer value;
+  buffer pointer value;
+  bufferLength uns(10) value;
+end-pr;
+
+dcl-s CRLF char(2) inz(x'0d0a') ccsid(819); 
+
+
+//
+// Procedures
+//
+dcl-proc test_parseSimpleRequest export;
+  dcl-s abnormallyEnded ind;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  dcl-ds request likeds(il_request);
+  
+  request = createRequest();
+  
+  httpMessage = 'GET /index.html HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('GET') : il_getRequestMethod(request));
+  aEqual(utf8('localhost') : il_getRequestHeader(request : 'Host'));
+  aEqual(utf8('/index.html') : il_getRequestResource(request));
+  
+  on-exit abnormallyEnded;
+    disposeRequest(request);
+end-proc;
+
+
+dcl-proc test_parseGetMultipleHeader export;
+  dcl-s abnormallyEnded ind;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  dcl-ds request likeds(il_request);
+  
+  request = createRequest();
+  
+  httpMessage = 'GET /index.html HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + 'Accept: application/json' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('GET') : il_getRequestMethod(request));
+  aEqual(utf8('localhost') : il_getRequestHeader(request : 'Host'));
+  aEqual(utf8('application/json') : il_getRequestHeader(request : 'Accept'));
+  
+  on-exit abnormallyEnded;
+    disposeRequest(request);
+end-proc;
+
+
+dcl-proc test_headerCaseInsensitivity export;
+  dcl-s abnormallyEnded ind;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  dcl-ds request likeds(il_request);
+  
+  request = createRequest();
+  
+  httpMessage = 'GET /index.html HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + 'Accept: application/json' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('application/json') : il_getRequestHeader(request : 'Accept'));
+  aEqual(utf8('application/json') : il_getRequestHeader(request : 'accept'));
+  aEqual(utf8('application/json') : il_getRequestHeader(request : 'ACCEPT'));
+  aEqual(utf8('application/json') : il_getRequestHeader(request : 'aCCept'));
+  
+  on-exit abnormallyEnded;
+    disposeRequest(request);
+end-proc;
+
+
+dcl-proc test_headerNotExist export;
+  dcl-s abnormallyEnded ind;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  dcl-ds request likeds(il_request);
+  
+  request = createRequest();
+  
+  httpMessage = 'GET /index.html HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('') : il_getRequestHeader(request : 'NotExistingHeader'));
+  
+  on-exit abnormallyEnded;
+    disposeRequest(request);
+end-proc;
+
+
+dcl-proc test_headerEmptyHeaderValue export;
+  dcl-s abnormallyEnded ind;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  dcl-ds request likeds(il_request);
+  
+  request = createRequest();
+  
+  httpMessage = 'GET /index.html HTTP/1.1' + CRLF + 'Host: ' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('') : il_getRequestHeader(request : 'Host'));
+  
+  on-exit abnormallyEnded;
+    disposeRequest(request);
+end-proc;
+
+
+dcl-proc utf8;
+  dcl-pi *n varchar(1024) ccsid(*utf8);
+    string varchar(1024) const;
+  end-pi;
+  
+  return string;
+end-proc;
+
+
+dcl-proc createRequest;
+  dcl-pi *n likeds(il_request) end-pi;
+
+  dcl-ds request likeds(il_request) inz;
+  dcl-ds headerList likeds(il_varchar) based(headerListPtr);
+  
+  request.config = %alloc(%size(il_config));
+  
+  headerListPtr = %alloc(%size(il_varchar));
+  clear headerList;
+  request.headerList = headerListPtr;
+  
+  return request;
+end-proc;
+
+
+dcl-proc disposeRequest;
+  dcl-pi *n;
+    request likeds(il_request);
+  end-pi;
+  
+  dealloc request.config;
+  dealloc request.headerList;
+end-proc;
+
+
+dcl-proc setup export;
+
+end-proc;
+
+
+dcl-proc teardown export;
+
+end-proc;


### PR DESCRIPTION
I tested it with iRPGUnit but it should also work with the original RPGUnit as iRPGUnit is a fork of RPGUnit and the copybook which is included in the unit tests has the same prototypes.

I needed to change the signature of lookForHeaders. I remove the static keyword so that it is exported and can be consumed by the unit tests. I don't know if this is the only way to get the function exported.

I also had to fix ileastic.c, parseHeaders, as the unit tests always failed with the variable _end_ in line 187 getting a NULL value which later resulted in an escape message.

Example header = Host: localhost

I also added the last part of the storage address

```
93C H   <-- begin at start
93D o
93E s
93F t
940 : 
941 
942 l
943 o
944 c
945 a
946 l
947 h
948 o
949 s 
94A t
94B cr     <-- headerend
94C lf
94D cr
94E lf
```

I think this constellation would not work as

`end  = memmem(begin, headend - begin , eol , 2); // Find end of line`

never find the end because CRLF is not included as the range ends with headerend which points to CR. But perhaps I am missing some crucial points here. C is not my native language ;-)