### PR TITLE
fixed upper/lower case of filenames

### DIFF
--- a/headers/base64.h
+++ b/headers/base64.h
@@ -1,4 +1,4 @@
-﻿#ifndef BASE64_H
+#ifndef BASE64_H
 #define BASE64_H
 void il_encodeBase64 (PLVARCHAR output, PLVARCHAR input );
 void il_decodeBase64 (PLVARCHAR output, PLVARCHAR input );

--- a/headers/sysdef.h
+++ b/headers/sysdef.h
@@ -4,7 +4,7 @@
 #include <regex.h>
 #include "ostypes.h"
 #include "xlate.h"
-#include "simplelist.h"
+#include "simpleList.h"
 #include "fcgi_stdio.h"
 
 

--- a/src/api.c
+++ b/src/api.c
@@ -42,7 +42,7 @@
 #include "sysdef.h"
 #include "strUtil.h"
 #include "streamer.h"
-#include "simplelist.h"
+#include "simpleList.h"
 #include "sndpgmmsg.h"
 #include "parms.h"
 #include "e2aa2e.h"

--- a/src/fastCGI.c
+++ b/src/fastCGI.c
@@ -33,7 +33,7 @@
 #include "sysdef.h"
 #include "strUtil.h"
 #include "streamer.h"
-#include "simplelist.h"
+#include "simpleList.h"
 #include "sndpgmmsg.h"
 #include "parms.h"
 #include "e2aa2e.h"

--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -44,7 +44,7 @@
 #include "strUtil.h"
 #include "e2aa2e.h"
 #include "xlate.h"
-#include "simplelist.h"
+#include "simpleList.h"
 #include "parms.h"
 #include "fcgi_stdio.h"
 

--- a/src/simpleList.c
+++ b/src/simpleList.c
@@ -16,7 +16,7 @@
 
 #include "ostypes.h" 
 #include "varchar.h" 
-#include "simplelist.h"
+#include "simpleList.h"
 
 
 /* --------------------------------------------------------------------------- *\


### PR DESCRIPTION
The case of the filenames is important if the source is compile under the QOpenSys filesystem which is more unix like and differentiates between upper and lower case of filenames. The filenames are now in a state that they compile in QOpenSys. (Though I could not test the included projects noxDB and ILEfastCGI).