### PR TITLE
fixed accessing query string without having passed a query string

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -121,17 +121,20 @@ void il_getParmStr  (PLVARCHAR out , PREQUEST pRequest , PUCHAR parmName , PLVAR
     
     PSLIST pParmList = pRequest->parmList; 
 
-	for (pNode = pParmList->pHead; pNode; pNode=pNode->pNext) {
-		PSLISTKEYVAL parm = pNode->payloadData;
-        if (keyLen == parm->key.Length) {
-            len = urldecodeBuf( temp  , parm->key.String , keyLen);
-            mema2e(aKey , temp, len ); // The parms are in ASCII
-            if (memicmp (parmName , aKey , keyLen) == 0) {
-                out->Length = urldecodeBuf( out->String, parm->value.String ,  parm->value.Length);
-                return ;
-            }
-        }
+	if (pParmList != NULL) {
+		for (pNode = pParmList->pHead; pNode; pNode=pNode->pNext) {
+			PSLISTKEYVAL parm = pNode->payloadData;
+			if (keyLen == parm->key.Length) {
+				len = urldecodeBuf( temp  , parm->key.String , keyLen);
+				mema2e(aKey , temp, len ); // The parms are in ASCII
+				if (memicmp (parmName , aKey , keyLen) == 0) {
+					out->Length = urldecodeBuf( out->String, parm->value.String ,  parm->value.Length);
+					return ;
+				}
+			}
+		}
 	}
+	
     out->Length = dft->Length;
     substr(out->String , dft->String , dft->Length); 
 }

--- a/unittests/request.rpgle
+++ b/unittests/request.rpgle
@@ -40,6 +40,9 @@ dcl-pr test_rootResource end-pr;
 dcl-pr test_deeplyStructuredResource end-pr;
 dcl-pr test_resouceWithQueryStringWithReservedChars end-pr;
 dcl-pr test_rootResourceWithMissingQueryStringValue end-pr;
+dcl-pr test_rootResourceWithMissingQueryStringDefaultValue end-pr;
+dcl-pr test_rootResourceWithEmptyQueryParameter end-pr;
+dcl-pr test_rootResourceWithEmptyQueryParameterDefaultValue end-pr;
 
 
 // BOOL lookForHeaders ( PREQUEST pRequest, PUCHAR buf , ULONG bufLen)
@@ -179,6 +182,7 @@ dcl-proc test_rootResource export;
   aEqual(utf8('/') : il_getRequestResource(request));
 end-proc;
 
+
 dcl-proc test_simpleResource export;
   dcl-s httpMessage varchar(1000) ccsid(819);
   
@@ -216,6 +220,36 @@ dcl-proc test_rootResourceWithMissingQueryStringValue export;
   lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
   
   aEqual(utf8('') : il_getParmStr(request : 'client'));
+end-proc;
+
+
+dcl-proc test_rootResourceWithMissingQueryStringDefaultValue export;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  
+  httpMessage = 'GET / HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('1234') : il_getParmStr(request : 'client' : '1234'));
+end-proc;
+
+
+dcl-proc test_rootResourceWithEmptyQueryParameter export;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  
+  httpMessage = 'GET /?client HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('') : il_getParmStr(request : 'client'));
+end-proc;
+
+
+dcl-proc test_rootResourceWithEmptyQueryParameterDefaultValue export;
+  dcl-s httpMessage varchar(1000) ccsid(819);
+  
+  httpMessage = 'GET /?client HTTP/1.1' + CRLF + 'Host: localhost' + CRLF + CRLF;
+  lookForHeaders(%addr(request) : %addr(httpMessage : *data) : %len(httpMessage));
+  
+  aEqual(utf8('') : il_getParmStr(request : 'client' : '1234'));
 end-proc;
 
 


### PR DESCRIPTION
Accessing the query parameter without any query parameters in the url of the request threw an escape message. Fixes issue #29 and #38.

Added some test cases to cover this, see unit test request.