### PR TITLE
added BasicAuth plugin

### DIFF
--- a/headers/ileastic.rpgle
+++ b/headers/ileastic.rpgle
@@ -295,6 +295,16 @@ dcl-pr il_listen extproc(*CWIDEN:'il_listen');
     servlet     pointer(*PROC) value options(*nopass) ;
 end-pr;
 
+///
+// Add HTTP header entry to the response 
+//
+// Adds an HTTP header to the response sent to the client. The same  HTTP header
+// key can be added multiple times to the response, the old value is not replaced.
+//
+// @param response Response
+// @param HTTP header key
+// @param HTTP header value
+///
 dcl-pr il_addHeader extproc(*CWIDEN:'il_addHeader');
     response    likeds(il_response);
     header      varchar(256:2) const;
@@ -502,6 +512,8 @@ dcl-pr il_encodeBase64 varchar(524284:4) ccsid(*utf8) extproc(*CWIDEN : 'il_enco
 end-pr;
 
 ///
+// Add message to job log
+//
 // Curticy function: put messages in joblog
 // works like printf but with strings only like
 //    il_joblog('This is %s a test' : 'Super');
@@ -522,5 +534,17 @@ dcl-pr il_joblog extproc(*CWIDEN : 'il_joblog') ;
   string7       pointer  options(*string:*nopass) value;
   string8       pointer  options(*string:*nopass) value;
   string9       pointer  options(*string:*nopass) value;
+end-pr;
+
+///
+// Get thread local storage
+//
+// Returns a graph of the thread local storage. You can access the graph with
+// the noxDB API. Paths starting with /ileastic are framework specific values.
+//
+// @return Pointer to thread local storage
+///
+dcl-pr il_getThreadMem pointer extproc('il_getThreadMem');
+  request likeds(il_request);
 end-pr;
 

--- a/makefile
+++ b/makefile
@@ -11,6 +11,7 @@
 BIN_LIB=ILEASTIC
 LIBLIST=$(BIN_LIB)
 
+BIND_LIB=*LIBL
 
 # The shell we use
 SHELL=/QOpenSys/usr/bin/qsh
@@ -34,12 +35,12 @@ CCFLAGS2=OPTION(*STDLOGMSG) OUTPUT(*NONE) OPTIMIZE(10) ENUM(*INT) TERASPACE(*YES
 
 MODULES = $(BIN_LIB)/stream $(BIN_LIB)/ileastic $(BIN_LIB)/varchar $(BIN_LIB)/api $(BIN_LIB)/sndpgmmsg $(BIN_LIB)/strutil $(BIN_LIB)/e2aa2e $(BIN_LIB)/xlate $(BIN_LIB)/simpleList $(BIN_LIB)/serialize $(BIN_LIB)/base64 $(BIN_LIB)/fastCGI
 	
-all: env noxDB ILEfastCGI compile bind
+all: env compile bind
 
 env:
 	-system -qi "CRTLIB $(BIN_LIB) TYPE(*TEST) TEXT('ILEastic: Programmable applications server for ILE')"                                          
 	-system -qi "CRTBNDDIR BNDDIR($(BIN_LIB)/ILEASTIC)"
-	-system -qi "ADDBNDDIRE BNDDIR($(BIN_LIB)/ILEASTIC) OBJ((ILEASTIC))"
+	-system -qi "ADDBNDDIRE BNDDIR($(BIN_LIB)/ILEASTIC) OBJ(($(BIND_LIB)/ILEASTIC))"
 	system -qi "CHGATR OBJ('headers/*') ATR(*CCSID) VALUE(1208)"
 
 compile: .PHONY
@@ -58,21 +59,27 @@ bind:
 	system "CRTSRCPF FILE($(BIN_LIB)/QSRVSRC) RCDLEN(112)";\
 	system "CPYFRMSTMF FROMSTMF('headers/ileastic.bnd') TOMBR('/QSYS.lib/$(BIN_LIB).lib/QSRVSRC.file/ILEASTIC.mbr') MBROPT(*replace)";\
 	system -q "DLTOBJ OBJ($(BIN_LIB)/ILEASTIC) OBJTYPE(*SRVPGM)";\
-	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILEASTIC) MODULE($(MODULES)) BNDSRVPGM(($(BIN_LIB)/ILEFASTCGI *DEFER) ($(BIN_LIB)/JSONXML *DEFER)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - programable applicationserver for ILE')";\
+	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILEASTIC) MODULE($(MODULES)) BNDSRVPGM(($(BIND_LIB)/ILEFASTCGI *DEFER) ($(BIND_LIB)/JSONXML *DEFER)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - programable applicationserver for ILE')";
 
 clean:
 	-system -q "CLRLIB $(BIN_LIB)"
 
 test: .PHONY
 	cd unittests && make
-	
+
+plugins: .PHONY
+	cd plugins/authsystem && make BIN_LIB=$(BIN_LIB) BIND_LIB=$(BIND_LIB)
+	cd plugins/basicauth && make BIN_LIB=$(BIN_LIB) BIND_LIB=$(BIND_LIB)
+
 # For vsCode 
 current: env
 	system "CRTCMOD MODULE($(BIN_LIB)/$(SRC)) SRCSTMF('src/$(SRC).c') $(CCFLAGS2) "
 
+# install the copybooks in the user provided directory (variable USRINCDIR)
 install:
 	-mkdir $(USRINCDIR)/ILEastic
 	cp headers/ileastic.rpgle $(USRINCDIR)/ILEastic/
+	cp plugins/basicauth/basicauth_h.rpgle $(USRINCDIR)/ILEastic/
 
 .PHONY:
 

--- a/plugins/authsystem/authsystem.bnd
+++ b/plugins/authsystem/authsystem.bnd
@@ -1,0 +1,5 @@
+STRPGMEXP PGMLVL(*CURRENT) SIGNATURE('AuthSystem 1.0.0')
+
+    EXPORT SYMBOL("il_auth_system")
+
+ENDPGMEXP

--- a/plugins/authsystem/authsystem.rpgle
+++ b/plugins/authsystem/authsystem.rpgle
@@ -1,0 +1,103 @@
+**FREE
+
+///
+// ILEastic : System Authentication Provider
+//
+// This ILEastic plugin retrieves the username and password from the thread
+// local storage and tries to validate the user at the system it is running
+// on.
+//
+// The credentials are expected at the following paths:
+//
+// /ileastic/auth/username and /ileastic/auth/password
+//
+// If this plugin cannot authenticate the user the plugin chain will be
+// interrupted by returning *off from this plugin procedure. Additionally
+// an HTTP response will be sent with status 401.
+//
+// The plugin retrieving the credentials from the HTTP request and putting
+// it into the thread local storage must be registered before this plugin
+// so that this plugin is called _after_ the other one.
+//
+// @author Mihael Schmidt
+// @date   05.03.2019
+///
+
+ctl-opt nomain thread(*concurrent);
+
+/include 'noxDB/headers/JSONXML.rpgle'
+/include 'headers/ileastic.rpgle'
+
+dcl-ds qusec_t qualified template;
+  bytesProvided int(10);
+  bytesAvailable int(10);
+  exceptionId char(7);
+  reserved char(2);
+end-ds;
+
+dcl-pr il_auth_system ind extproc(*dclcase);
+  request  likeds(il_request);
+  response likeds(il_response);
+end-pr;
+
+
+dcl-proc il_auth_system export;
+  dcl-pi *n ind;
+    request  likeds(il_request);
+    response likeds(il_response);
+  end-pi;
+
+  dcl-s json pointer;
+  dcl-s username varchar(4094:2);
+  dcl-s password varchar(4094:2);
+  dcl-s valid ind;
+
+  json = il_getThreadMem(request);
+  username = jx_getStr(json : '/ileastic/auth/username');
+  password = jx_getStr(json : '/ileastic/auth/password');
+
+  if (username = *blank or password = *blank);
+    return *off;
+  else;
+    if (isValidUser(username : password));
+      return *on;
+    else;
+      response.status = 401;
+      response.statusText = 'Unauthorized';
+      il_responseWrite(response : 'Invalid credentials.');
+      return *off;
+    endif;
+  endif;
+end-proc;
+
+
+dcl-proc isValidUser;
+  dcl-pi *n ind;
+    username char(10) const;
+    password char(512) const;
+  end-pi;
+
+  dcl-pr sys_getProfileHandle extpgm('QSYGETPH');
+    username char(10) const;
+    password char(512) const;
+    profileHandle char(12);
+    errorCode likeds(qusec_t);
+    passwordLength int(10) const;
+    passwordCcsid int(10) const;
+  end-pr;
+
+  dcl-pr sys_releaseProfileHandle extpgm('QSYRLSPH');
+    profileHandle char(12) const;
+  end-pr;
+
+  dcl-s profileHandle char(12);
+  dcl-ds errorCode likeds(qusec_t) inz;
+
+  monitor;
+    sys_getProfileHandle(username : password : profileHandle : errorCode : %len(%trimr(password)) : 0);
+    sys_releaseProfileHandle(profileHandle);
+    return *on;
+  on-error *all;
+    return *off;
+  endmon;
+end-proc;

--- a/plugins/authsystem/authsystem_h.rpgle
+++ b/plugins/authsystem/authsystem_h.rpgle
@@ -1,0 +1,27 @@
+**FREE
+
+/if defined (ILAUTHSYS)
+/eof
+/endif
+
+/define ILAUTHSYS
+
+///
+// ILEastic : System Authentification Plugin
+//
+// This module is an ILEastic plugin which retrieves the authentification 
+// information from the thread local memory of the request
+//
+// /ileastic/auth/username and /ileastic/auth/password
+//
+// and tries to authenticate on the system.
+//
+// Use can use this plugin by adding the following statement:
+//
+//     il_addPlugin(config : %paddr('il_auth_system') : IL_PREREQUEST);
+//
+// @author Mihael Schmidt
+// @date   05.03.2019
+//
+// @info The plugin should be registered on the IL_PREREQUEST event.
+///

--- a/plugins/authsystem/makefile
+++ b/plugins/authsystem/makefile
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------------------------
+# User-defined part start
+#
+
+# note: ILE RPG compilers don't support UTF-8, so we use win-1252; However ILE C supports UTF-8
+
+# BIN_LIB is the destination library for the service program.
+# The rpg modules and the binder source file are also created in BIN_LIB.
+# Binder source file and rpg module can be remove with the clean step 
+# (make clean).
+BIN_LIB=ILEASTIC
+
+BIND_LIB=*LIBL
+
+#
+# User-defined part end
+#-------------------------------------------------------------------------------
+
+
+# CFLAGS = compiler parameter
+CFLAGS=OUTPUT(*PRINT) OPTION(*NOUNREF *SRCSTMT) DBGVIEW(*LIST) STGMDL(*INHERIT) INCDIR('../..')
+
+MODULES = authsystem
+
+.SUFFIXES: .rpgle
+
+.rpgle:
+	system -ik "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCSTMF('$<') $(CFLAGS)"
+	
+all: env compile bind
+
+env:
+	-system -qi "ADDBNDDIRE BNDDIR($(BIN_LIB)/ILEASTIC) OBJ(($(BIND_LIB)/ILAUTHSYS))"
+	
+compile: $(MODULES)
+
+bind:
+	system -q "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)";\
+	system "CRTSRCPF FILE($(BIN_LIB)/QSRVSRC) RCDLEN(112)";\
+	system "CPYFRMSTMF FROMSTMF('authsystem.bnd') TOMBR('/QSYS.lib/$(BIN_LIB).lib/QSRVSRC.file/ILAUTHSYS.mbr') MBROPT(*replace)";\
+	system -q "DLTOBJ OBJ($(BIN_LIB)/ILAUTHSYS) OBJTYPE(*SRVPGM)";\
+	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILAUTHSYS) MODULE($(BIN_LIB)/AUTHSYSTEM) BNDSRVPGM(($(BIN_LIB)/ILEASTIC) ($(BIN_LIB)/JSONXML)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - Auth System Plugin')";

--- a/plugins/basicauth/basicauth.bnd
+++ b/plugins/basicauth/basicauth.bnd
@@ -1,0 +1,6 @@
+STRPGMEXP PGMLVL(*CURRENT) SIGNATURE('BasicAuth 1.0.0')
+
+    EXPORT SYMBOL("il_basicauth")
+    EXPORT SYMBOL("il_basicauth_setRealm")
+
+ENDPGMEXP

--- a/plugins/basicauth/basicauth.rpgle
+++ b/plugins/basicauth/basicauth.rpgle
@@ -1,0 +1,142 @@
+**FREE
+
+///
+// ILEastic : BasicAuth Plugin
+//
+// This module is an ILEastic plugin which retrieves the BasicAuth information
+// from a HTTP request and stores the credentials in the thread local memory
+// of the request.
+//
+// /ileastic/auth/username and /ileastic/auth/password
+//
+// Access to the thread local memory can be achieved through the procedure
+// il_getThreadMem(request). It returns a json graph from the noxDB project.
+// The single values from the graph can be retrieved with
+// jx_getStr(json : '/ileastic/auth/username') to get the username f. e. .
+//
+// @author Mihael Schmidt
+// @date   05.03.2019
+//
+// @info The realm should be set with il_basicauth_setRealm().
+//
+// @info The plugin should be registered on the IL_PREREQUEST event.
+//
+// @warning The credentials need to be in UTF-8 before being Base64 encoded.
+///
+
+
+ctl-opt nomain thread(*concurrent);
+
+
+/include 'basicauth_h.rpgle'
+/include 'headers/ileastic.rpgle'
+/include 'noxDB/headers/JSONXML.rpgle'
+
+dcl-pr il_basicauth ind extproc(*dclcase);
+  request  likeds(il_request);
+  response likeds(il_response);
+end-pr;
+  
+
+dcl-s realm varchar(100) inz('unknown');
+
+
+///
+// BasicAuth support
+//
+// The username and password will be extracted from the HTTP headers and put
+// into the thread local storage of the request. If the credentials cannot 
+// be fetched from the HTTP headers a 401 HTTP message will be sent.
+//
+// @param Request
+// @param Response
+///
+dcl-proc il_basicauth export;
+  dcl-pi *n ind;
+    request  likeds(il_request);
+    response likeds(il_response);
+  end-pi;
+
+  dcl-s basicAuthHeader varchar(4094:2);
+  dcl-s decodedHeader varchar(4094:2);
+  dcl-s x int(10);
+  dcl-s username varchar(4094:2);
+  dcl-s password varchar(4094:2);
+  dcl-s json pointer;
+
+  basicAuthHeader = il_getRequestHeader(request : 'Authorization');
+  if (basicAuthHeader = *blank);
+    sendUnauthorizedResponse(request : response);
+  else;
+    if (isAuthTypeBasic(basicAuthHeader));
+      x = %scan(' ' : basicAuthHeader);
+      decodedHeader = il_decodeBase64(%trim(%subst(basicAuthHeader : x+1)));
+
+      x = %scan(':' : decodedHeader);
+      if (x = 0);
+        username = decodedHeader;
+      else;
+        username = %subst(decodedHeader : 1 : x-1);
+        password = %subst(decodedHeader : x+1);
+      endif;
+
+      json = il_getThreadMem(request);
+      jx_setStr(json : '/ileastic/auth/username' : username);
+      if (password <> *blank);
+        jx_setStr(json : '/ileastic/auth/password' : password);
+      endif;
+
+      return *on;
+
+    else;
+      sendUnauthorizedResponse(request : response);
+    endif;
+  endif;
+
+  return *off;
+end-proc;
+
+
+dcl-proc il_basicauth_setRealm export;
+  dcl-pi *n;
+    pRealm like(realm) const;
+  end-pi;
+  
+  realm = pRealm;
+end-proc;
+
+
+dcl-proc isAuthTypeBasic;
+  dcl-pi *n ind;
+    header varchar(4094:2) const;
+  end-pi;
+
+  dcl-c UPPER 'BASIC';
+  dcl-c LOWER 'basic';
+  dcl-s authType char(10);
+  dcl-s x int(10);
+  
+  x = %scan(' ' : header);
+  if (x > 0);
+    authType = %trim(%subst(header : 1 : x-1));
+    authType = %xlate(UPPER : LOWER : authType);
+    
+    return authType = 'basic';
+  endif;
+  
+  return *off;
+end-proc;
+
+
+dcl-proc sendUnauthorizedResponse;
+  dcl-pi *n;
+    request  likeds(il_request);
+    response likeds(il_response);
+  end-pi;
+
+  // return 401 with the http header: WWW-Authenticate: Basic realm="User Visible Realm", charset="UTF-8"
+  response.status = 401;
+  response.statusText = 'Unauthorized';
+  il_addHeader(response : 'WWW-Authenticate' : 'Basic realm="' + realm + '", charset="UTF-8"');
+  il_responseWrite(response : 'Invalid Authorization');
+end-proc;

--- a/plugins/basicauth/basicauth_h.rpgle
+++ b/plugins/basicauth/basicauth_h.rpgle
@@ -1,0 +1,44 @@
+**FREE
+
+/if defined (ILBASICAUT)
+/eof
+/endif
+
+/define ILBASICAUT
+
+///
+// ILEastic : BasicAuth Plugin
+//
+// This module is an ILEastic plugin which retrieves the BasicAuth information
+// from a HTTP request and stores the credentials in the thread local memory
+// of the request.
+//
+// /ileastic/auth/username and /ileastic/auth/password
+//
+// Access to the thread local memory can be achieved through the procedure
+// il_getThreadMem(request). It returns a json graph from the noxDB project.
+// The single values from the graph can be retrieved with
+// jx_getStr(json : '/ileastic/auth/username') to get the username f. e. .
+//
+// @author Mihael Schmidt
+// @date   05.03.2019
+//
+// @info The realm should be set with il_basicauth_setRealm().
+//
+// @info The plugin should be registered on the IL_PREREQUEST event.
+//
+// @warning The credentials need to be in UTF-8 before being Base64 encoded.
+///
+
+///
+// Set realm for BasicAuth
+//
+// Sets the realm for BasicAuth support.
+//
+// @param Realm
+//
+// @info The realm for BasicAuth must be set prior to starting the server.
+///
+dcl-pr il_basicauth_setRealm extproc(*dclcase);
+  realm varchar(100) const;
+end-pr;

--- a/plugins/basicauth/makefile
+++ b/plugins/basicauth/makefile
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------------------------
+# User-defined part start
+#
+
+# note: ILE RPG compilers don't support UTF-8, so we use win-1252; However ILE C supports UTF-8
+
+# BIN_LIB is the destination library for the service program.
+# The rpg modules and the binder source file are also created in BIN_LIB.
+# Binder source file and rpg module can be remove with the clean step 
+# (make clean).
+BIN_LIB=ILEASTIC
+
+BIND_LIB=*LIBL
+
+#
+# User-defined part end
+#-------------------------------------------------------------------------------
+
+
+# CFLAGS = compiler parameter
+CFLAGS=OUTPUT(*PRINT) OPTION(*NOUNREF *SRCSTMT) DBGVIEW(*LIST) STGMDL(*INHERIT) INCDIR('../..')
+
+MODULES = basicauth
+
+.SUFFIXES: .rpgle
+
+.rpgle:
+	system -ik "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCSTMF('$<') $(CFLAGS)"
+	
+all: env compile bind
+
+env:
+	-system -qi "ADDBNDDIRE BNDDIR($(BIN_LIB)/ILEASTIC) OBJ(($(BIND_LIB)/ILBASICAUT))"
+
+compile: $(MODULES)
+
+bind:
+	system -q "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)";\
+	system "CRTSRCPF FILE($(BIN_LIB)/QSRVSRC) RCDLEN(112)";\
+	system "CPYFRMSTMF FROMSTMF('basicauth.bnd') TOMBR('/QSYS.lib/$(BIN_LIB).lib/QSRVSRC.file/ILBASICAUT.mbr') MBROPT(*replace)";\
+	system -q "DLTOBJ OBJ($(BIN_LIB)/ILBASICAUT) OBJTYPE(*SRVPGM)";\
+	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILBASICAUT) MODULE($(BIN_LIB)/BASICAUTH) BNDSRVPGM(($(BIN_LIB)/ILEASTIC) ($(BIN_LIB)/JSONXML)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - BasicAuth Plugin')";


### PR DESCRIPTION
Added plugin for BasicAuth support. Also added plugin for authenticating with provided credentials at the system.

The plugins are not build by default. They can be build with the build target "plugins".

Added BIND_LIB variable. The project can now be build with the *LIBL for resolving service programs and also with providing a specific library. This is then used for binding the service programs when creating ILEASTIC and also for the entries in the binding directory. Default is *LIBL.