### PR TITLE
fixed basic auth realm not available for all threads

### DIFF
--- a/plugins/basicauth/basicauth.rpgle
+++ b/plugins/basicauth/basicauth.rpgle
@@ -38,7 +38,7 @@ dcl-pr il_basicauth ind extproc(*dclcase);
 end-pr;
   
 
-dcl-s realm varchar(100) inz('unknown');
+dcl-s realm varchar(100) inz('unknown') static(*allthread);
 
 
 ///


### PR DESCRIPTION
With thread(*concurrent) the realm variable would be created for each thread. So the executing thread would not get the value set from the user on the main thread. "static(*allthread) on the realm variable fixed that.