### PR TITLE
added missing HTTP method constants to RPG copybook, fixed #74

### DIFF
--- a/headers/ileastic.rpgle
+++ b/headers/ileastic.rpgle
@@ -413,6 +413,14 @@ dcl-c IL_PUT     8;
 ///
 dcl-c IL_OPTIONS 16;
 ///
+// HTTP method HEAD
+///
+dcl-c IL_HEAD 32;
+///
+// HTTP method PATCH
+///
+dcl-c IL_PATCH 64;
+///
 // Any HTTP method (used for adding servlets to the server for any HTTP method)
 ///
 dcl-c IL_ANY     const(1023);


### PR DESCRIPTION
Added the HTTP methods HEAD and PATCH. Fixed issue #74.