### PR TITLE
fixed passing utf8 encoded parameters

### DIFF
--- a/plugins/jwt/jwt_h.rpgle
+++ b/plugins/jwt/jwt_h.rpgle
@@ -53,8 +53,8 @@ dcl-s jwt_signKey_t varchar(1000) template;
 // @return *on = valid and not expired else *off
 ///
 dcl-pr jwt_verify ind extproc(*dclcase);
-  token like(jwt_token_t) const;
-  signKey like(jwt_signKey_t) const;
+  token like(jwt_token_t) const ccsid(*utf8);
+  signKey like(jwt_signKey_t) const ccsid(*utf8);
 end-pr;
 
 ///
@@ -65,8 +65,8 @@ end-pr;
 // @param Token
 // @return Decoded header
 ///
-dcl-pr jwt_decodeHeader like(jwt_token_t) extproc(*dclcase);
-  token like(jwt_token_t) const;
+dcl-pr jwt_decodeHeader like(jwt_token_t) ccsid(*utf8) extproc(*dclcase);
+  token like(jwt_token_t) const ccsid(*utf8);
 end-pr;
 
 ///
@@ -77,8 +77,8 @@ end-pr;
 // @param token
 // @return Decoded payload
 ///
-dcl-pr jwt_decodePayload like(jwt_token_t) extproc(*dclcase);
-  token like(jwt_token_t) const;
+dcl-pr jwt_decodePayload like(jwt_token_t) ccsid(*utf8) extproc(*dclcase);
+  token like(jwt_token_t) const ccsid(*utf8);
 end-pr;
 
 ///
@@ -95,10 +95,10 @@ end-pr;
 //
 // @info At the moment only HS256 is supported for signature creation.
 ///
-dcl-pr jwt_sign like(jwt_token_t) extproc(*dclcase);
+dcl-pr jwt_sign like(jwt_token_t) ccsid(*utf8) extproc(*dclcase);
   algorithm char(100) const;
-  payload like(jwt_token_t) const;
-  signKey like(jwt_signKey_t) const;
+  payload like(jwt_token_t) const ccsid(*utf8);
+  signKey like(jwt_signKey_t) const ccsid(*utf8);
 end-pr;
 
 ///
@@ -111,5 +111,5 @@ end-pr;
 // @return *on = token has expired else *off
 ///
 dcl-pr jwt_isExpired ind extproc(*dclcase);
-  payload like(jwt_token_t) const;
+  payload like(jwt_token_t) const ccsid(*utf8);
 end-pr;

--- a/plugins/jwt/jwtplugin.rpgle
+++ b/plugins/jwt/jwtplugin.rpgle
@@ -30,7 +30,7 @@ dcl-s signKey like(jwt_signKey_t) static(*allthread) ccsid(*utf8);
 
 dcl-proc il_jwt_setSignKey export;
   dcl-pi *n;
-    pSignKey like(jwt_signKey_t) const;
+    pSignKey like(jwt_signKey_t) const ccsid(*utf8);
   end-pi;
   
   signKey = pSignKey;
@@ -59,7 +59,7 @@ dcl-proc il_jwt_filter export;
       return validRequest;
     endif;
 
-    if (isValidToken(token));
+    if (jwt_verify(token : signKey));
       payload = jwt_decodePayload(token);
       json = json_parseString(payload);
 
@@ -84,22 +84,6 @@ dcl-proc il_jwt_filter export;
   endmon;
 
   return validRequest;
-end-proc;
-
-
-dcl-proc isValidToken;
-  dcl-pi *n ind;
-    token like(jwt_token_t) const;
-  end-pi;
-
-  dcl-s valid ind inz(*off);
-  dcl-s payload like(jwt_token_t);
-
-  if (jwt_verify(token : signKey));
-    valid = *on;
-  endif;
-
-  return valid;
 end-proc;
 
 

--- a/plugins/jwt/jwtplugin_h.rpgle
+++ b/plugins/jwt/jwtplugin_h.rpgle
@@ -30,7 +30,7 @@
 // @param Sign key
 ///
 dcl-pr il_jwt_setSignKey extproc(*dclcase);
-  signKey like(jwt_signKey_t) const;
+  signKey like(jwt_signKey_t) const ccsid(*utf8);
 end-pr;
 
 

--- a/plugins/jwt/makefile
+++ b/plugins/jwt/makefile
@@ -27,6 +27,7 @@ MODULES = jwt jwtplugin
 .SUFFIXES: .rpgle
 
 .rpgle:
+	system -i "CHGATR OBJ('$<') ATR(*CCSID) VALUE(819)"
 	system -ik "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCSTMF('$<') $(CFLAGS)"
 	
 all: env compile bind

--- a/plugins/jwt/makefile
+++ b/plugins/jwt/makefile
@@ -2,8 +2,6 @@
 # User-defined part start
 #
 
-# note: ILE RPG compilers don't support UTF-8, so we use win-1252; However ILE C supports UTF-8
-
 # BIN_LIB is the destination library for the service program.
 # The rpg modules and the binder source file are also created in BIN_LIB.
 # Binder source file and rpg module can be remove with the clean step 
@@ -28,22 +26,32 @@ MODULES = jwt jwtplugin
 
 .rpgle:
 	system -i "CHGATR OBJ('$<') ATR(*CCSID) VALUE(819)"
-	system -ik "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCSTMF('$<') $(CFLAGS)"
+	-system -i "RMVM FILE($(BIN_LIB)/JWTSRC) MBR($@)"
+	system -i "CPYFRMSTMF FROMSTMF('$<') TOMBR('/QSYS.LIB/$(BIN_LIB).LIB/JWTSRC.FILE/$@.MBR') MBROPT(*ADD)"
+	system -i "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCFILE($(BIN_LIB)/JWTSRC) SRCMBR($@) $(CFLAGS)"
 	
 all: env compile bind
 
 env:
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/JWTSRC) OBJTYPE(*FILE)"
+	system -i "CRTSRCPF FILE($(BIN_LIB)/JWTSRC) RCDLEN(200)"
 	-system -qi "ADDBNDDIRE BNDDIR($(BIN_LIB)/ILEASTIC) OBJ(($(BIND_LIB)/JWT))"
 	-system -qi "ADDBNDDIRE BNDDIR($(BIN_LIB)/ILEASTIC) OBJ(($(BIND_LIB)/ILJWTPLUG))"
 
 compile: $(MODULES)
 
 bind:
-	system -q "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)";\
-	system "CRTSRCPF FILE($(BIN_LIB)/QSRVSRC) RCDLEN(112)";\
-	system "CPYFRMSTMF FROMSTMF('jwt.bnd') TOMBR('/QSYS.lib/$(BIN_LIB).lib/QSRVSRC.file/JWT.mbr') MBROPT(*replace)";\
-	system -q "DLTOBJ OBJ($(BIN_LIB)/JWT) OBJTYPE(*SRVPGM)";\
-	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/JWT) MODULE($(BIN_LIB)/JWT) BNDSRVPGM(($(BIN_LIB)/ILEASTIC) ($(BIN_LIB)/JSONXML)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - JWT')";\
-	system "CPYFRMSTMF FROMSTMF('jwtplugin.bnd') TOMBR('/QSYS.lib/$(BIN_LIB).lib/QSRVSRC.file/ILJWTPLUG.mbr') MBROPT(*replace)";\
-	system -q "DLTOBJ OBJ($(BIN_LIB)/ILJWTPLUG) OBJTYPE(*SRVPGM)";\
-	system -kpieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILJWTPLUG) MODULE($(BIN_LIB)/JWTPLUGIN) BNDSRVPGM(($(BIND_LIB)/ILEASTIC) ($(BIND_LIB)/JSONXML) ($(BIND_LIB)/JWT)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - JWT Plugin')";
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)"
+	system -i "CRTSRCPF FILE($(BIN_LIB)/QSRVSRC) RCDLEN(112)"
+	system -i "CPYFRMSTMF FROMSTMF('jwt.bnd') TOMBR('/QSYS.LIB/$(BIN_LIB).LIB/QSRVSRC.FILE/JWT.MBR') MBROPT(*ADD)"
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/JWT) OBJTYPE(*SRVPGM)"
+	system -pieb "CRTSRVPGM SRVPGM($(BIN_LIB)/JWT) MODULE($(BIN_LIB)/JWT) BNDSRVPGM(($(BIN_LIB)/ILEASTIC) ($(BIN_LIB)/JSONXML)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - JWT')"
+	system -i "CPYFRMSTMF FROMSTMF('jwtplugin.bnd') TOMBR('/QSYS.LIB/$(BIN_LIB).LIB/QSRVSRC.FILE/ILJWTPLUG.MBR') MBROPT(*ADD)"
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/ILJWTPLUG) OBJTYPE(*SRVPGM)"
+	system -pieb "CRTSRVPGM SRVPGM($(BIN_LIB)/ILJWTPLUG) MODULE($(BIN_LIB)/JWTPLUGIN) BNDSRVPGM(($(BIND_LIB)/ILEASTIC) ($(BIND_LIB)/JSONXML) ($(BIND_LIB)/JWT)) OPTION(*DUPPROC) DETAIL(*BASIC) STGMDL(*INHERIT) SRCFILE($(BIN_LIB)/QSRVSRC) TEXT('ILEastic - JWT Plugin')"
+
+clean:
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)"
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/JWTSRC) OBJTYPE(*FILE)"
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/JWT) OBJTYPE(*MODULE)"
+	-system -qi "DLTOBJ OBJ($(BIN_LIB)/JWTPLUGIN) OBJTYPE(*MODULE)"


### PR DESCRIPTION
This commit fixes the passing of parameters to the various procedures, functions and system API. Also the build of the JWT plugin has been fixed.

The JWT module needs to be compiled from a source member atm probably because of some CCSID issues. The makefile has been adjusted to that fact.

Now the JWT plugin is compatible with all the other JWT libraries.