### PR TITLE
added claims on signing JWT token

### DIFF
--- a/plugins/jwt/jwt.rpgle
+++ b/plugins/jwt/jwt.rpgle
@@ -23,6 +23,12 @@ ctl-opt nomain thread(*concurrent);
 /include 'headers/ileastic.rpgle'
 /include 'noxdb/headers/jsonparser.rpgle'
 
+dcl-pr sys_getUtcOffset extproc('CEEUTCO');
+  offsetHours int(10);
+  offsetMinutes int(10);
+  offsetSeconds float(8);
+  feedback char(12) options(*omit);
+end-pr;
 
 dcl-c UNIX_EPOCH_START z'1970-01-01-00.00.00.000000';
 dcl-s UTF8_PERIOD char(1) inz('.') CCSID(*UTF8);
@@ -108,8 +114,9 @@ end-proc;
 dcl-proc jwt_sign export;
   dcl-pi *n like(jwt_token_t) ccsid(*utf8);
     algorithm char(100) const;
-    payload like(jwt_token_t) const ccsid(*utf8);
+    pPayload like(jwt_token_t) const ccsid(*utf8);
     signKey like(jwt_signKey_t) const ccsid(*utf8);
+    claims likeds(jwt_claims_t) const options(*nopass);
   end-pi;
 
   dcl-pr memcpy pointer extproc('memcpy');
@@ -155,7 +162,9 @@ dcl-proc jwt_sign export;
   dcl-ds keyparam likeds(keyd0200_t) inz;
   dcl-s base64Encoded like(jwt_token_t) ccsid(*utf8);
   dcl-s paddingChar char(1) inz('=') ccsid(*utf8);
-
+  dcl-s payload like(jwt_token_t) ccsid(*utf8);
+  
+  
   if (algorithm <> jwt_HS256);
     il_joblog('Unsupported algorithm %s' : algorithm);
     return *blank;
@@ -163,6 +172,11 @@ dcl-proc jwt_sign export;
 
   header = '{"alg":"' + jwt_HS256 + '","typ":"JWT"}';
 
+  payload = pPayload;
+  if (%parms() >= 4);
+    payload = addClaims(payload : claims);
+  endif;
+  
   base64Encoded = encodeBase64Url(payload);
   base64Encoded = %trimr(base64Encoded : paddingChar);
   headerPayload = encodeBase64Url(header) + '.' + base64Encoded;
@@ -200,17 +214,77 @@ dcl-proc jwt_sign export;
 end-proc;
 
 
+dcl-proc addClaims;
+  dcl-pi *n like(jwt_token_t) ccsid(*utf8);
+    pPayload like(jwt_token_t) const ccsid(*utf8);
+    claims likeds(jwt_claims_t) const;
+  end-pi;
+
+  dcl-s payload like(jwt_token_t) ccsid(*utf8);
+  dcl-s json pointer;
+  dcl-s value like(jwt_token_t);
+  dcl-s uxts int(10);
+  dcl-s changed ind inz(*off);
+  
+  payload = %trimr(pPayload) + x'00';
+  
+  json = json_parseString(%addr(payload : *DATA));
+  
+  if (%len(claims.issuer) > 0);
+    value = claims.issuer + x'00';
+    json_setStr(json : 'iss' : %addr(value : *DATA));
+    changed = *on;
+  endif;
+  
+  if (%len(claims.subject) > 0);
+    value = claims.subject + x'00';
+    json_setStr(json : 'sub' : %addr(value : *DATA));
+    changed = *on;
+  endif;
+  
+  if (%len(claims.audience) > 0);
+    value = claims.audience + x'00';
+    json_setStr(json : 'aud' : %addr(value : *DATA));
+    changed = *on;
+  endif;
+  
+  if (%len(claims.jwtId) > 0);
+    value = claims.jwtId + x'00';
+    json_setStr(json : 'jti' : %addr(value : *DATA));
+    changed = *on;
+  endif;
+  
+  if (claims.expirationTime <> *loval);
+    uxts = toUnixTimestamp(claims.expirationTime);
+    json_setInt(json : 'exp' : uxts);
+    changed = *on;
+  endif;
+  
+  if (claims.notBefore <> *loval);
+    uxts = toUnixTimestamp(claims.notBefore);
+    json_setInt(json : 'nbf' : uxts);
+    changed = *on;
+  endif;
+  
+  if (claims.issuedAt <> *loval);
+    uxts = toUnixTimestamp(claims.issuedAt);
+    json_setInt(json : 'iat' : uxts);
+    changed = *on;
+  endif;
+  
+  if (changed);
+    payload = json_asJsonText(json);
+    return payload;
+  else;
+    return pPayload;
+  endif;
+end-proc;
+
+
 dcl-proc jwt_isExpired export;
   dcl-pi *n ind;
     pPayload like(jwt_token_t) const ccsid(*utf8);
   end-pi;
-
-  dcl-pr sys_getUtcOffset extproc('CEEUTCO');
-    offsetHours int(10);
-    offsetMinutes int(10);
-    offsetSeconds float(8);
-    feedback char(12) options(*omit);
-  end-pr;
 
   dcl-s payload like(jwt_token_t);
   dcl-s expired ind inz(*off);
@@ -268,3 +342,22 @@ dcl-proc decodeBase64Url;
 
   return decoded;
 end-proc;
+
+
+dcl-proc toUnixTimestamp;
+  dcl-pi *n int(10);
+    ts timestamp const;
+  end-pi;
+
+  dcl-s offsetHours int(10);
+  dcl-s offsetMinutes int(10);
+  dcl-s offsetSeconds float(8);
+  dcl-s uxts int(10);
+  
+  sys_getUtcOffset(offsetHours : offsetMinutes : offsetSeconds : *omit);
+  
+  uxts = %diff(ts : UNIX_EPOCH_START : *SECONDS) - %int(offsetSeconds);
+  
+  return uxts;
+end-proc;
+

--- a/plugins/jwt/jwt_h.rpgle
+++ b/plugins/jwt/jwt_h.rpgle
@@ -13,17 +13,14 @@
 //
 // The padding character = is stripped from the end of the token.
 //
-// @info The token generated with this service program are not necessarily 
-//       compatible with every JWT library because the parts of the token are 
-//       base64 encoded and some libraries use base64url encoding which is 
-//       not really compatible with base64 (see characters / and + which are 
-//       replace with - and _).
-//
-// @info At the moment only HS256 is supported.
+// @info Only HS256 is supported.
 //
 // @author Mihael Schmidt
 // @date   04.05.2019
 // @project ILEastic
+//
+// @rev 06.06.2020 Mihael Schmidt
+//      Added registered claims to token generation.
 ///
 
 ///
@@ -40,6 +37,22 @@ dcl-s jwt_token_t varchar(8090) template;
 // Template for the signing key which is used to create the token signature.
 ///
 dcl-s jwt_signKey_t varchar(1000) template;
+
+///
+// Template for registered claims. The data structure needs to be created with
+// inz(*likeds). Default values mean that the claim will not be added to the 
+// token. Note: Fields are varchar and any space will be added to the token, use
+// %trimr if you are using char variables.
+///
+dcl-ds jwt_claims_t qualified template;
+  issuer varchar(1000) inz;
+  subject varchar(1000) inz;
+  audience varchar(1000) inz;
+  expirationTime timestamp inz(*loval);
+  notBefore timestamp inz(*loval);
+  issuedAt timestamp inz(*loval);
+  jwtId varchar(1000) inz;
+end-ds;
 
 ///
 // Verify token
@@ -85,12 +98,14 @@ end-pr;
 // Create JWT token
 //
 // Creates a JWT token by creating a signature from the header + payload with
-// the passed signing key.
+// the passed signing key. If the claims data structure is passed then every
+// non-default value will be added to the token payload.
 //
 // @param Algorithm (HS256)
-// @parma Payload
+// @param Payload
 // @param Signing key (it has to be of a valid length corresponding to the 
 //        selected algorithm (HS256 => 256 key = char(32))
+// @param Registered claims
 // @return Signed token
 //
 // @info At the moment only HS256 is supported for signature creation.
@@ -99,6 +114,7 @@ dcl-pr jwt_sign like(jwt_token_t) ccsid(*utf8) extproc(*dclcase);
   algorithm char(100) const;
   payload like(jwt_token_t) const ccsid(*utf8);
   signKey like(jwt_signKey_t) const ccsid(*utf8);
+  claims likeds(jwt_claims_t) const options(*nopass);
 end-pr;
 
 ///

--- a/plugins/jwt/jwtut1.rpgmod
+++ b/plugins/jwt/jwtut1.rpgmod
@@ -1,0 +1,125 @@
+**FREE
+
+ctl-opt nomain;
+
+
+/include RPGUNIT/QINCLUDE,ASSERT
+/include 'jwt_h.rpgle'
+
+
+dcl-proc test_verify export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey);
+  
+  assert(jwt_verify(token : signKey) : 'Token must be verified successfully.');
+end-proc;
+
+
+dcl-proc test_notExpired export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-ds claims likeds(jwt_claims_t) inz(*likeds);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  claims.issuedAt = %timestamp();
+  claims.expirationTime = claims.issuedAt + %days(1);
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey : claims);
+  
+  assert(jwt_verify(token : signKey) : 'Token must be verified successfully.');
+end-proc;
+
+
+dcl-proc test_expired export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-ds claims likeds(jwt_claims_t) inz(*likeds);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  claims.issuedAt = %timestamp();
+  claims.expirationTime = claims.issuedAt - %days(1);
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey : claims);
+  
+  assert(not jwt_verify(token : signKey) : 'Token should not be successfully verified as it is expired.');
+end-proc;
+
+
+dcl-proc test_inactive export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-ds claims likeds(jwt_claims_t) inz(*likeds);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  claims.issuedAt = %timestamp();
+  claims.notBefore = claims.issuedAt + %days(1);
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey : claims);
+  
+  assert(not jwt_verify(token : signKey) : 'Token should not be successfully verified as it is not active.');
+end-proc;
+
+
+dcl-proc test_active export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-ds claims likeds(jwt_claims_t) inz(*likeds);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  claims.issuedAt = %timestamp();
+  claims.notBefore = claims.issuedAt - %days(1);
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey : claims);
+  
+  assert(jwt_verify(token : signKey) : 'Token should be successfully verified as it is active.');
+end-proc;
+
+
+dcl-proc test_activeExpired export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-ds claims likeds(jwt_claims_t) inz(*likeds);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  claims.issuedAt = %timestamp();
+  claims.expirationTime = claims.issuedAt - %days(1);
+  claims.notBefore = claims.issuedAt - %days(2);
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey : claims);
+  
+  assert(not jwt_verify(token : signKey) : 'Token should not be successfully verified as it is expired.');
+end-proc;
+
+
+dcl-proc test_activeNotExpired export;
+  dcl-s signKey like(jwt_signKey_t);
+  dcl-ds claims likeds(jwt_claims_t) inz(*likeds);
+  dcl-s payload varchar(100);
+  dcl-s token like(jwt_token_t);
+  
+  signKey = '123456789012345678901234567890AB';
+  payload = '{ "sub" : "test" , "name" : "Mihael" }';
+  claims.issuedAt = %timestamp();
+  claims.expirationTime = claims.issuedAt + %days(10);
+  claims.notBefore = claims.issuedAt - %days(2);
+  
+  token = jwt_sign(JWT_HS256 : payload : signKey : claims);
+  
+  assert(jwt_verify(token : signKey) : 'Token should be successfully verified as it is active and not expired.');
+end-proc;

--- a/plugins/jwt/makefile
+++ b/plugins/jwt/makefile
@@ -28,7 +28,7 @@ MODULES = jwt jwtplugin
 	system -i "CHGATR OBJ('$<') ATR(*CCSID) VALUE(819)"
 	-system -i "RMVM FILE($(BIN_LIB)/JWTSRC) MBR($@)"
 	system -i "CPYFRMSTMF FROMSTMF('$<') TOMBR('/QSYS.LIB/$(BIN_LIB).LIB/JWTSRC.FILE/$@.MBR') MBROPT(*ADD)"
-	system -i "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCFILE($(BIN_LIB)/JWTSRC) SRCMBR($@) $(CFLAGS)"
+	system -ikK "CRTRPGMOD MODULE($(BIN_LIB)/$@) SRCFILE($(BIN_LIB)/JWTSRC) SRCMBR($@) $(CFLAGS)"
 	
 all: env compile bind
 


### PR DESCRIPTION
The RFC for JWT specifies some registered claims which are also used by other JWT libraries. To make it easier to set those claims a parameter has been added to the signing procedure.

The notBefore (nbf) claim is now checked on JWT verification.

Also a memory leak on JWT verification has been fixed.

And a unit test added.