### PR TITLE
Fully-qualify gmake in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -44,13 +44,13 @@ env:
 	system -qi "CHGATR OBJ('headers/*') ATR(*CCSID) VALUE(1208)"
 
 compile: .PHONY
-	cd src && gmake
+	cd src && /QOpenSys/pkgs/bin/gmake
 
 noxDB: .PHONY
-	cd noxDB && gmake BIN_LIB=$(BIN_LIB)
+	cd noxDB && /QOpenSys/pkgs/bin/gmake BIN_LIB=$(BIN_LIB)
 
 ILEfastCGI: .PHONY
-	cd ILEfastCGI && gmake BIN_LIB=$(BIN_LIB)
+	cd ILEfastCGI && /QOpenSys/pkgs/bin/gmake BIN_LIB=$(BIN_LIB)
 
 		
 bind:


### PR DESCRIPTION
If `PATH` is only configured for bash, then the usage of `qsh` in the makefile can result in 
```
qsh: 001-0019 Error found searching for command gmake. No such path or directory.
```
In my case, my environment was set up with the [ibmi-dotfiles](https://github.com/jbh/ibmi-dotfiles/) project, and I encountered the above error. One of several workarounds is to fully-qualify the path to gmake. 