### PR TITLE
Last chunk is added two times causing client issue when no routing

### DIFF
--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -94,8 +94,15 @@ void putChunk (PRESPONSE pResponse, PUCHAR buf, LONG len)
 {
     int rc;
     LONG   lenleni;
-    PUCHAR tempBuf = memAlloc ( len + 16);
-    PUCHAR wrkBuf = tempBuf;
+    PUCHAR tempBuf;
+    PUCHAR wrkBuf;
+
+    if (len == 0) {
+        return;
+    }
+
+    tempBuf = memAlloc ( len + 16);
+    wrkBuf = tempBuf;
 
     prepareResponse  (pResponse);
 
@@ -131,6 +138,10 @@ void putChunkXlate (PRESPONSE pResponse, PUCHAR buf, LONG len)
     PUCHAR totBuf;
     PUCHAR input;
     size_t inbytesleft, outbytesleft, totalWriteLen ;
+
+    if (len == 0) {
+        return;
+    }
 
     prepareResponse  (pResponse);
 


### PR DESCRIPTION
putChunk function should be secured for sending data with 0 length, otherwise last-chunk is multiplied.
https://www.rfc-editor.org/rfc/rfc2616#section-3.6.1
`last-chunk     = 1*("0") [ chunk-extension ] CRLF`