### PR TITLE
Skip all CRLF from the begining of buffer

### DIFF
--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -437,6 +437,9 @@ BOOL lookForHeaders ( PREQUEST pRequest, PUCHAR buf , ULONG bufLen)
     // No end-of-headers in this buffer, the just continue
     if (eoh == NULL)      return false;
 
+    // Skip all CRLF from the begining of buffer
+    for (;*buf == 0x0d || *buf == 0x0a; buf ++, bufLen --);
+
     // got the end of header; Now parse the HTTP header
     pRequest->completeHeader.String = buf;
     pRequest->completeHeader.Length = eoh - buf;


### PR DESCRIPTION
I already use this code as a solution for #134.
It’s hard to say if this is something that should be fixed, but all other applications that I use work fine