### PR TITLE
Remove json_close call

### DIFF
--- a/plugins/jwt/jwtplugin.rpgmod
+++ b/plugins/jwt/jwtplugin.rpgmod
@@ -156,7 +156,6 @@ dcl-proc il_jwt_filter export;
   endmon;
 
   on-exit;
-      json_close(json);
 end-proc;
 
 


### PR DESCRIPTION
Remove json_close call as it's breaking JSON structure with token data in request thread local memory