### PR TITLE
Assign rpgle editor for rpginc and rpgmod extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
-        "*.sqlrpgle": "rpg",
+        "*.rpginc": "rpgle",
+        "*.rpgmod": "rpgle",
         "*.dmd": "json",
         "*.widget": "javascript",
         "strutil.h": "c",


### PR DESCRIPTION
Assign **rpgle** editor to **rpginc** and rpgmod. **rpgle** and **sqlrpgle** seem to be correctly assigned out of the box.