### PR TITLE
Install copy books from plugins' makefiles.

### DIFF
--- a/makefile
+++ b/makefile
@@ -83,10 +83,11 @@ clean:
 test: .PHONY
 	cd unittests && $(MAKE)
 
-plugins: .PHONY
-	cd plugins/cors && $(MAKE) all SHELL=$(SHELL)
-	cd plugins/authsystem && $(MAKE) all SHELL=$(SHELL)
-	cd plugins/basicauth && $(MAKE) all SHELL=$(SHELL)
+PLUGINS = cors authsystem basicauth
+$(PLUGINS): .PHONY
+	cd plugins/$@ && $(MAKE) all SHELL=$(SHELL)
+
+plugins: $(PLUGINS)
 
 # For vsCode 
 current: env
@@ -97,8 +98,14 @@ current: env
 install:
 	-mkdir $(USRINCDIR)/ILEastic
 	cp headers/ileastic.rpgle $(USRINCDIR)/ILEastic/
-	cp plugins/basicauth/basicauth_h.rpgle $(USRINCDIR)/ILEastic/
-	cp plugins/cors/cors_h.rpginc $(USRINCDIR)/ILEastic/
+	$(eval cwd := $(shell pwd))
+	set -e; \
+	for plugin in $(PLUGINS); \
+	do \
+		cd plugins/$$plugin; \
+		$(MAKE) $@ SHELL=$(SHELL); \
+		cd $(cwd); \
+	done
 
 .PHONY:
 

--- a/plugins/authsystem/makefile
+++ b/plugins/authsystem/makefile
@@ -54,3 +54,6 @@ clean:
 
 purge: clean
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/ILAUTHSYS) OBJTYPE(*SRVPGM)"
+
+install:
+	cp authsystem_h.rpgle $(USRINCDIR)/ILEastic/

--- a/plugins/basicauth/makefile
+++ b/plugins/basicauth/makefile
@@ -55,3 +55,6 @@ clean:
 
 purge: clean
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/ILBASICAUT) OBJTYPE(*SRVPGM)"
+
+install:
+	cp basicauth_h.rpgle $(USRINCDIR)/ILEastic/

--- a/plugins/cors/Makefile
+++ b/plugins/cors/Makefile
@@ -55,3 +55,6 @@ clean:
 
 purge: clean
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/CORS) OBJTYPE(*SRVPGM)"
+
+install:
+	cp cors_h.rpginc $(USRINCDIR)/ILEastic/

--- a/plugins/jwt/makefile
+++ b/plugins/jwt/makefile
@@ -83,3 +83,6 @@ purge: clean
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/ILJWTPLUG) OBJTYPE(*SRVPGM)"
 
 .PHONY:
+
+install:
+	cp jwtplugin.rpginc $(USRINCDIR)/ILEastic/

--- a/plugins/openAPI/makefile
+++ b/plugins/openAPI/makefile
@@ -70,3 +70,5 @@ clean:
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/QSRVSRC) OBJTYPE(*FILE)"
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/OPENAPISRC) OBJTYPE(*FILE)"
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/OPENAPI) OBJTYPE(*MODULE)"
+
+install:

--- a/plugins/openapi-static/Makefile
+++ b/plugins/openapi-static/Makefile
@@ -75,5 +75,7 @@ clean:
 	-system -qi "DLTOBJ OBJ($(BIN_LIB)/OAPISRCGEN) OBJTYPE(*CMD)"
 	$(MAKE) -C ext/llist/ clean $*
 
+install:
+
 .PHONY:
 


### PR DESCRIPTION
Get plugin list to build from a variable. This will allow overriding plugin list that is built by default by passing a parameter to make.