### PR TITLE
Added TLS support 

### DIFF
--- a/TLS.md
+++ b/TLS.md
@@ -1,0 +1,60 @@
+# TLS Support in ILEastic
+
+ILEastic uses IBM's [GSKit](https://www.ibm.com/docs/en/i/7.5.0?topic=sockets-global-security-kit-gskit-apis)
+library for TLS/SSL encryption.
+
+Currently ILEastic only supports non-default certificate stores. Those certificate stores are stored
+as stream files in the IFS.
+
+## Self Signed Certificates
+
+Self signed certificates can be created with the PASE tool `openssl` and the
+[Digital Certificate Manager](https://www.ibm.com/docs/en/i/7.5.0?topic=security-digital-certificate-manager).
+
+Create self signed server certificate:
+
+```
+openssl req -x509  -newkey rsa:2048  -nodes  -keyout server.key  -out server.crt  -days 365  \
+    -subj "/C=DE/ST=NRW/L=Minden/O=RPGNextGen/CN=ILEastic"  \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"  \
+    -addext "keyUsage=digitalSignature,keyEncipherment"  \
+    -addext "extendedKeyUsage=serverAuth"
+```
+
+Check content of our certificate:
+
+```
+openssl x509 -in server.crt -text -noout
+```
+
+DCM does not seem to like x509 for importing certificates so we need another format like PKCS12. `openssl` can create a PKCS12 version of our certificate:
+
+```
+openssl pkcs12 -export -in server.crt -inkey server.key -out server.p12 -name server-cert -passout pass:changeit
+```
+
+Now extracting the public portion of the certificate for usage by the client:
+
+```
+openssl x509 -in server.crt -pubkey -out server.pub
+```
+
+For GSKit we need a certificate store created by the Digital Certificate Manager. So start DCM by calling https://my_ibmi:2006/dcm .
+
+Steps:
+
+- create new certificate store (other)
+- import the PKCS12 certificate to the new certificate store
+- set new certificate as default in certificate store
+
+The new certificate store can now be used with ILEastic:
+
+```
+il_setKeyfile(config : '/my/path/to/the/certificate/store/server.kdb' : 'changeit');
+```
+
+Test with curl:
+
+```
+curl -v --cacert server.pub --url https://localhost:35800
+```

--- a/headers/ileastic.bnd
+++ b/headers/ileastic.bnd
@@ -34,4 +34,5 @@ STRPGMEXP PGMLVL(*CURRENT) SIGNATURE('ILEastic 1.1.2')
     EXPORT SYMBOL("il_mediatype_getPreferredAcceptedMediaType")
     EXPORT SYMBOL("il_mediatype_isMediaTypeAccepted")
     EXPORT SYMBOL("il_mediatype_parseMediaType")
+    EXPORT SYMBOL("il_setKeyfile")
 ENDPGMEXP

--- a/headers/ileastic.rpgle
+++ b/headers/ileastic.rpgle
@@ -1043,3 +1043,22 @@ dcl-pr il_mediatype_isMediaTypeAccepted likeds(mediaType_t) extproc(*dclcase);
   mediaType9     pointer value options(*string:*nopass);
   mediaType10    pointer value options(*string:*nopass);
 end-pr;
+
+///
+// Set certificate
+//
+// Sets the certificate to be used which automatically triggers the activation
+// of HTTPS.
+//
+// @param Configuration
+// @param IFS path to the certificate store (kdb)
+// @param Password for the certificate store
+//
+// @info When setting the certificate store the service only accepts HTTPS requests.
+//       HTTP requests are ignored.
+///
+dcl-pr il_setKeyfile extproc(*dclcase);
+    config likeds(il_config);
+    keyfilePath varchar(256) const;
+    keyfilePassword varchar(64) const options(*nopass);
+end-pr;

--- a/headers/sysdef.h
+++ b/headers/sysdef.h
@@ -2,6 +2,7 @@
 #define  SYSDEF_H
 
 #include <regex.h>
+#include <gskssl.h>
 #include "ostypes.h"
 #include "xlate.h"
 #include "simpleList.h"
@@ -79,6 +80,8 @@ typedef _Packed struct _CONFIG  {
     FCGI        fcgi;
     SCHEDULER   scheduler;
     ULONG       schedulerTimer;
+    gsk_handle  envHandle;
+    gsk_handle  sessionHandle;
 } CONFIG,  *PCONFIG;
 
 typedef _Packed struct _HEADERLIST  {

--- a/itests/Makefile
+++ b/itests/Makefile
@@ -1,0 +1,59 @@
+#
+# Build script for ILEastic Integration Test
+#
+
+
+#-------------------------------------------------------------------------------
+# User-defined part start
+#
+
+# BIN_LIB is the destination library for the unit tests.
+BIN_LIB=ILEASTIC
+
+# This library contains the ILEASTIC modules.
+ILEASTIC_LIB=ILEASTIC
+
+ILEVATOR_LIB=ILEVATOR
+ILEVATOR_INCDIR=/usr/local/include/ilevator
+
+RPGUNIT_LIB=RPGUNIT
+
+OUTPUT=*NONE
+
+TARGET_RLS=*CURRENT
+#
+# User-defined part end
+#-------------------------------------------------------------------------------
+
+# system and application include folder
+INCLUDE='.' '/QIBM/include' '../headers/' '../ILEfastCGI/include' '../noxDB/headers' '$(ILEVATOR_INCDIR)'
+
+.SUFFIXES: .rpgle
+
+.rpgle:
+	system -i "CHGATR OBJ('$<') ATR(*CCSID) VALUE(1252)"
+
+OBJECTS = ILBASICS ILBASICST
+SRVPGMS = $(ILEASTIC_LIB)/ILEFASTCGI $(ILEASTIC_LIB)/JSONXML $(ILEASTIC_LIB)/ILEASTIC $(RPGUNIT_LIB)/RUTESTCASE $(ILEVATOR_LIB)/ILEVATOR
+
+all: clean compile
+
+main:
+	cd .. && $(MAKE)
+
+compile: $(OBJECTS)
+
+ILBASICS: ilbasics
+	system -i "CRTRPGMOD MODULE($(BIN_LIB)/ILBASICS) SRCSTMF('ilbasics.rpgle') INCDIR($(INCLUDE)) DBGVIEW(*LIST) OUTPUT($(OUTPUT)) STGMDL(*SNGLVL) TGTRLS($(TARGET_RLS))"
+	system -i "CRTPGM $(BIN_LIB)/ILBASICS STGMDL(*SNGLVL) BNDSRVPGM($(SRVPGMS)) OPTION(*DUPPROC) TGTRLS($(TARGET_RLS))"
+
+ILBASICST: ilbasicst
+	system -i "CRTRPGMOD MODULE($(BIN_LIB)/ILBASICST) SRCSTMF('ilbasicst.rpgle') INCDIR($(INCLUDE)) DBGVIEW(*LIST) OUTPUT($(OUTPUT)) STGMDL(*SNGLVL) TGTRLS($(TARGET_RLS))"
+	system -i "CRTSRVPGM $(BIN_LIB)/ILBASICST STGMDL(*SNGLVL) BNDSRVPGM($(SRVPGMS)) OPTION(*DUPPROC) TGTRLS($(TARGET_RLS)) EXPORT(*ALL)"
+
+clean:
+	-system -i "DLTMOD $(BIN_LIB)/ILBASICS"
+	-system -i "DLTPGM $(BIN_LIB)/ILBASICS"
+	-system -i "DLTMOD $(BIN_LIB)/ILBASICST"
+	-system -i "DLTSRVPGM $(BIN_LIB)/ILBASICST"
+	

--- a/itests/README.md
+++ b/itests/README.md
@@ -1,0 +1,31 @@
+# Integration Tests
+
+## Basics
+
+The program `ILBASICS` provides web service endpoints which covers the most common features of HTTP.
+It supports HTTP and HTTPS. HTTPS can be activated by supplying a certificate store via environment
+variables.
+
+- ILEASTIC_ITEST_KEYFILE_PATH : IFS path to the certifcate store
+- ILEASTIC_ITEST_KEYFILE_SECRET : Secret for the certificate store
+- ILEASTIC_ITEST_PORT : Server socket port
+
+```
+ADDENVVAR ENVVAR(ILEASTIC_ITEST_KEYFILE_PATH) VALUE('/var/local/etc/cert/rpgnextgen/server.kdb')
+ADDENVVAR ENVVAR(ILEASTIC_ITEST_KEYFILE_SECRET) VALUE('changeit')
+ADDENVVAR ENVVAR(ILEASTIC_ITEST_PORT) VALUE(44001)
+```
+
+The RPGUnit test suite `ILBASICST` uses RPGunit to execute tests and executes HTTP request to 
+`ILBASICS` by using the HTTP client ILEvator. It supports HTTP and HTTPS. HTTPS can be activated by
+supplying a certificate store via environment variables.
+
+- ILEASTIC_ITEST_KEYFILE_PATH : IFS path to the certifcate store
+- ILEASTIC_ITEST_KEYFILE_SECRET : Secret for the certificate store
+- IILEASTIC_ITEST_BASE_URL : Base URL of the web service, default: http://localhost:44000
+
+```
+ADDENVVAR ENVVAR(ILEASTIC_ITEST_KEYFILE_PATH) VALUE('/var/local/etc/cert/rpgnextgen/server.kdb')
+ADDENVVAR ENVVAR(ILEASTIC_ITEST_KEYFILE_SECRET) VALUE('changeit')
+ADDENVVAR ENVVAR(ILEASTIC_ITEST_BASE_URL) VALUE('https://localhost:44001')
+```

--- a/itests/assert.rpgle
+++ b/itests/assert.rpgle
@@ -1,0 +1,109 @@
+      /if not defined (IRPGUNIT_ASSERT)
+      /define IRPGUNIT_ASSERT
+
+      /include 'templates.rpginc'
+       
+
+       //----------------------------------------------------------------------
+       //   Procedure Prototypes
+       //----------------------------------------------------------------------
+
+       // Assertion procedure prototypes.
+
+       // aEqual -- Aphanumeric Equality Assertion
+       // Assert that two alphanumeric variables are equal.
+       //
+       // Example:
+       //   aEqual( 'John Smith' : name );
+
+     D aEqual          pr                  extproc('aEqual')
+     D  expected                  32565a   const
+     D  actual                    32565a   const
+     D  fieldName                    64a   const varying options(*nopass: *omit)
+
+
+       // assert -- General Purpose Assertion
+       // Assert that a condition is true. If not, a failure message percolates.
+       //
+       // Examples:
+       //   assert( newTime > oldTime : 'newTime is not larger than oldTime' );
+       //   assert( %not eof : 'Missing record in file XXX' );
+
+     D assert          pr                  extproc('assert')
+     D  condition                      n   const
+      /if defined(RPGUNIT_INTERNAL)
+     D  msgIfFalse                  256a   const
+      /else
+     D  msgIfFalse                16384a   const varying options(*Varsize)
+      /endif
+
+
+       // fail -- Fail Primitive
+       // Percolate an RPGUnit failure message.
+       //
+       // Example:
+       //   monitor;
+       //     call PGM();
+       //     fail( 'PGM should have thrown an exception' );
+       //   on-error;
+       //     // Exception seen. Success.
+       //   endmon;
+
+     D fail            pr                  extproc('fail')
+      /if defined(RPGUNIT_INTERNAL)
+     D  msg                         256a   const
+      /else
+     D  msg                       16384a   const varying options(*Varsize)
+      /endif
+
+
+       // iEqual -- Integer Equality Assertion
+       //
+       // Assert that two integer variables are equal.
+       // Example:
+       //   iEqual( 1000 : balance );
+
+     D iEqual          pr                  extproc('iEqual')
+     D  expected                     31s 0 const
+     D  actual                       31s 0 const
+     D  fieldName                    64a   const varying options(*nopass: *omit)
+
+
+       // nEqual -- Boolean Equality Assertion
+       //
+       // Assert that two boolean variables are equal.
+       // Example:
+       //   iEqual( *ON : isFound );
+
+     D nEqual          pr                  extproc('nEqual')
+     D  expected                       n   const
+     D  actual                         n   const
+     D  fieldName                    64a   const varying options(*nopass: *omit)
+     
+     
+     D assertJobLogContains...
+     D                 pr                  extproc('assertJobLogContains')
+     D  msgId                         7a   const
+     D  timeLimit                      z   const
+     
+     
+     
+     D clrAssertFailEvt...
+     D                 pr                  extproc('clrAssertFailEvt')
+
+     D getAssertCalled...
+     D                 pr            10i 0 extproc('getAssertCalled')
+
+     D getAssertFailEvt...
+     D                 pr                  extproc('getAssertFailEvt')
+     D                                     likeds(AssertFailEvt_t)
+
+     D getAssertFailEvtLong...
+     D                 pr                  extproc('getAssertFailEvtLong')
+     D                                     likeds(AssertFailEvtLong_t)
+
+     D clearAssertCounter...
+     D                 pr                  extproc('clearAssertCounter')
+
+      /endif
+      

--- a/itests/ilbasics.rpgle
+++ b/itests/ilbasics.rpgle
@@ -8,7 +8,7 @@
 // Start it:
 //
 // ADDLIBLE ILEASTIC
-// SBMJOB CMD(CALL PGM(ILBASICS)) JOB(ILEASTIC) JOBQ(QSYSNOMAX) ALWMLTTHD(*YES)
+// SBMJOB CMD(CALL PGM(ILBASICS)) JOB(ILEASTIC) JOBQ(QSYSNOMAX) ALWMLTTHD(*YES) CPYENVVAR(*YES)
 // 
 // @info It requires your RPG code to be reentrant and compiled for 
 //       multithreading. Each client request is handled by a seperate thread.
@@ -69,7 +69,7 @@ end-proc;
 
 
 dcl-proc main;
-    dcl-ds config likeds(il_config);
+    dcl-ds config likeds(il_config) inz;
     
     init();
 

--- a/itests/ilbasics.rpgle
+++ b/itests/ilbasics.rpgle
@@ -1,0 +1,276 @@
+**FREE
+
+///
+// Integration Test : Basics
+//
+// This test covers all the basics one would encounter in a CRUD application.
+//
+// Start it:
+//
+// ADDLIBLE ILEASTIC
+// SBMJOB CMD(CALL PGM(ILBASICS)) JOB(ILEASTIC) JOBQ(QSYSNOMAX) ALWMLTTHD(*YES)
+// 
+// @info It requires your RPG code to be reentrant and compiled for 
+//       multithreading. Each client request is handled by a seperate thread.
+///
+
+ctl-opt main(main) debug(*yes) thread(*CONCURRENT);
+
+
+/include ileastic
+/include jsonxml
+
+dcl-pr getenv pointer extproc('getenv');
+  envvar pointer value options(*string : *trim);
+end-pr;
+
+dcl-c REGEX_START u'005E';
+dcl-c BRACKET_OPEN u'005B';
+dcl-c BRACKET_CLOSE u'005D';
+dcl-c CURLY_OPEN u'007B';
+dcl-c CURLY_CLOSE u'007D';
+dcl-c REGEX_END u'0024';
+
+dcl-s book varchar(1000) static(*allthread);
+dcl-s port int(10) inz(44000);
+dcl-s keyFilePath varchar(1000);
+dcl-s keyFileSecret varchar(100);
+
+dcl-proc init;
+    dcl-s value pointer;
+
+    value = getenv('ILEASTIC_ITEST_KEYFILE_PATH');
+    if (value <> *null);
+        keyFilePath = %str(value);
+    endif;
+
+    value = getenv('ILEASTIC_ITEST_KEYFILE_SECRET');
+    if (value <> *null);
+        keyFileSecret = %str(value);
+    endif;
+
+    value = getenv('ILEASTIC_ITEST_PORT');
+    if (value <> *null);
+        port = %int(%str(value));
+    endif;
+
+    book = CURLY_OPEN;
+    book += '"id" : 358 , +
+        "title" : "The Vampire Lestat", +
+        "subtitle" : "Vampire Chronicles Book 2", +
+        "publisher" : "Random House Publishing Group", +
+        "language" : "english", +
+        "format" : "tradepaperback", +
+        "isbn" : "0345419642", +
+        "isbn13" : "978-0345419644", +
+        "relaseDate" : "1997-11-29" ';
+    book += CURLY_CLOSE;
+end-proc;
+
+
+dcl-proc main;
+    dcl-ds config likeds(il_config);
+    
+    init();
+
+    config.port = port; 
+    config.host = '*ANY';
+
+    if (keyFilePath <> *blank);
+        il_setKeyfile(config : keyFilePath : keyFileSecret);
+    endif;
+
+    il_addRoute(config : %paddr(test_getBookExcerpt) : IL_GET : REGEX_START + '/book/excerpt' + REGEX_END);
+    il_addRoute(config : %paddr(test_deleteBook) : IL_DELETE: REGEX_START + '/book/' + CURLY_OPEN + 'isbn' + CURLY_CLOSE + REGEX_END);
+    il_addRoute(config : %paddr(test_updateRating) : IL_PATCH : REGEX_START + '/book/' + CURLY_OPEN + 'isbn' + CURLY_CLOSE + '/rating' + REGEX_END);
+    il_addRoute(config : %paddr(test_bookExists) : IL_HEAD : REGEX_START + '/book/' + CURLY_OPEN + 'isbn' + CURLY_CLOSE + REGEX_END);
+    il_addRoute(config : %paddr(test_createBook) : IL_POST : REGEX_START + '/book' + REGEX_END);
+    il_addRoute(config : %paddr(test_search) : IL_GET : REGEX_START + '/book' + REGEX_END);
+    il_addRoute(config : %paddr(test_bookOptions) : IL_OPTIONS : REGEX_START + '/book' + REGEX_END);
+    il_addRoute(config : %paddr(test_notFound));
+
+    il_listen (config);
+end-proc;
+
+
+dcl-proc test_notFound;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    response.contentType = 'text/plain';
+    response.status = 404;
+    il_responseWrite(response: 'Route not found');
+end-proc;
+
+
+dcl-proc test_bookOptions;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    il_addHeader(response : 'Allow' : 'GET,POST');
+
+    response.status = 204;
+    il_responseWrite(response: '');
+end-proc;
+
+
+dcl-proc test_search;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    dcl-s q varchar(1000);
+    dcl-s accept varchar(100);
+
+    accept = il_getRequestHeader(request : 'accept');
+
+    if (not (accept = 'application/json' or accept = 'application/vnd.rpgnextgen.isbn'));
+        response.status = 415;
+        il_responseWrite(response : 'Only application/json and application/vnd.rpgnextgen.isbn supported');
+        return;
+    endif;
+
+    response.status = 200;
+
+    q = il_getQueryParameter(request : 'q' : '');
+    if (%scan('vampire' : q) > 0 or %scan('lestat' : q)  > 0);
+
+        il_addHeader(response : 'IL_BOOKS_COUNT' : '358');
+
+        if (accept = 'application/json');
+            il_responseWrite(response : BRACKET_OPEN + book + BRACKET_CLOSE);
+        else;
+            il_responseWrite(response : '0345419642');
+        endif;
+
+    else;
+        il_responseWrite(response : BRACKET_OPEN + BRACKET_CLOSE);
+    endif;
+end-proc;
+
+
+dcl-proc test_bookExists;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    dcl-s isbn varchar(20) ccsid(1208);
+
+    //  ISBN 0345419642 or 978-0345419644 : The Vampire Lestat
+    isbn = il_getPathParameter(request : 'isbn' : '');
+ 
+    if (isbn = '0345419642' or isbn = '978-0345419644');
+        response.status = 204;
+        il_responseWrite(response: '');
+    elseif (%len(isbn) = 10 or %len(isbn) = 14);
+        response.status = 404;
+        response.contentType = 'text/plain';
+        il_responseWrite(response : 'ISBN ' + isbn + ' not in store.');
+    else;
+        response.status = 400;
+        response.contentType = 'text/plain';
+        il_responseWrite(response: 'Valid length for ISBN is 10 and 13');
+    endif;
+end-proc;
+
+
+dcl-proc test_getBookExcerpt;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    il_responseWrite(response: 'We kissed tenderly amid the laughter and the +
+        reek of wine. Ah, the smell of innocent blood.');
+end-proc;
+
+
+dcl-proc test_createBook;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    dcl-s json pointer;
+    dcl-s messageBody varchar(10000);
+    dcl-s contentType varchar(100);
+
+    contentType = il_getRequestHeader(request : 'Content-Type');
+    if (contentType <> 'application/json');
+        response.status = 415;
+        il_responseWrite(response : 'Only application/json supported');
+        return;
+    endif;
+
+    messageBody = il_getRequestContent(request);
+    json = jx_parseString(messageBody);
+    jx_setInt(json : 'id' : 359);
+    jx_setNull(json : 'rating');
+
+    response.status = 201;
+    response.contentType = 'application/json';
+    il_responseWriteStream(response: jx_stream(json));
+
+    on-exit;
+        jx_close(json);
+end-proc;
+
+
+dcl-proc test_deleteBook;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    response.status = 204;
+    il_responseWrite(response: '');
+end-proc;
+
+
+dcl-proc test_updateRating;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    dcl-s rating int(5);
+    dcl-s json pointer;
+    dcl-s isbn varchar(20) ccsid(1208);
+
+    if (%len(request.contentType) >= 10 and %subst(request.contentType : 1 : 10) = 'text/plain');
+        response.status = 415;
+        il_responseWrite(response: 'Only text/plain supported');
+        return;
+    endif;
+
+    isbn = il_getPathParameter(request : 'isbn' : '');
+    if (isbn = '0345419642' or isbn = '978-0345419644');
+        monitor;
+            rating = %int(il_getRequestContent(request));
+        on-error;
+            response.status = 400;
+            il_responseWrite(response: 'Invalid rating');
+            return;
+        endmon;
+
+        json = jx_parseString(book);
+        jx_setInt(json : 'rating' : rating);
+        il_responseWriteStream(response : jx_stream(json));
+    elseif (%len(isbn) = 10 or %len(isbn) = 14);
+        response.status = 404;
+        il_responseWrite(response: 'ISBN ' + isbn + ' not in store.');
+    else;
+        response.status = 400;
+        response.contentType = 'text/plain';
+        il_responseWrite(response: 'Valid length for ISBN are 10 and 13');
+    endif;
+
+    on-exit;
+        jx_close(json);
+end-proc;

--- a/itests/ilbasicst.rpgle
+++ b/itests/ilbasicst.rpgle
@@ -1,0 +1,359 @@
+**FREE
+
+///
+// Integration Test Suite
+//
+// This test suite tests the different parts of ILEastic.
+//
+// @author Mihael Schmidt
+// @date   09.04.2026
+///
+
+
+ctl-opt nomain;
+
+
+/include assert
+/include ilevator
+/include jsonxml
+/include '../headers/ileastic.rpgle'
+
+dcl-pr getenv pointer extproc('getenv');
+  envvar pointer value options(*string : *trim);
+end-pr;
+
+dcl-c REGEX_START u'005E';
+dcl-c BRACKET_OPEN u'005B';
+dcl-c BRACKET_CLOSE u'005D';
+dcl-c CURLY_OPEN u'007B';
+dcl-c CURLY_CLOSE u'007D';
+dcl-c REGEX_END u'0024';
+
+dcl-pr setup end-pr;
+dcl-pr teardown end-pr;
+dcl-pr test_getWithQuery end-pr;
+dcl-pr test_getWithJsonAccept end-pr;
+dcl-pr test_getWithCustomAccept end-pr;
+dcl-pr test_getResponeHttpHeader end-pr;
+dcl-pr test_getEmptySearchResult end-pr;
+dcl-pr test_delete end-pr;
+dcl-pr test_patchAccepted end-pr;
+dcl-pr test_patchPathParameterValidation end-pr;
+dcl-pr test_patchNotFound end-pr;
+dcl-pr test_head end-pr;
+dcl-pr test_headNotFound end-pr;
+dcl-pr test_headErrorMessageBody end-pr;
+dcl-pr test_options end-pr;
+dcl-pr test_post end-pr;
+dcl-pr test_routeNotFound end-pr;
+
+
+dcl-s httpClient pointer;
+dcl-s keyFilePath varchar(1000);
+dcl-s keyFileSecret varchar(100);
+dcl-s baseUrl varchar(100);
+dcl-s buffer varchar(65000:4) ccsid(1208);
+dcl-s book varchar(1000);
+
+dcl-proc setup export;
+    dcl-s value pointer;
+
+    value = getenv('ILEASTIC_ITEST_KEYFILE_PATH');
+    if (value <> *null);
+        keyFilePath = %str(value);
+    endif;
+
+    value = getenv('ILEASTIC_ITEST_KEYFILE_SECRET');
+    if (value <> *null);
+        keyFileSecret = %str(value);
+    endif;
+
+    value = getenv('ILEASTIC_ITEST_BASE_URL');
+    if (value <> *null);
+        baseUrl = %str(value);
+    else;
+        baseUrl = 'http://localhost:44000';
+    endif;
+
+
+    httpClient = iv_newHttpClient();
+    iv_setTimeout(httpClient : 5);
+    iv_setRetries(httpClient : 1);
+    iv_setCertificate(httpClient : '/home/mschmidt/cert/rpgnextgen/server.kdb' : 'changeit');
+
+    book = BRACKET_OPEN;
+    book += CURLY_OPEN;
+    book += '"id" : 358 , +
+        "title" : "The Vampire Lestat", +
+        "subtitle" : "Vampire Chronicles Book 2", +
+        "publisher" : "Random House Publishing Group", +
+        "language" : "english", +
+        "format" : "tradepaperback", +
+        "isbn" : "0345419642", +
+        "isbn13" : "978-0345419644", +
+        "relaseDate" : "1997-11-29" ';
+    book += CURLY_CLOSE;
+    book += BRACKET_CLOSE;
+end-proc;
+
+
+dcl-proc teardown export;
+    iv_free(httpClient);
+end-proc;
+
+
+dcl-proc test_getWithQuery export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/book/excerpt?q=vampire%20lestat');
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    aEqual('We kissed tenderly amid the laughter and the reek of wine. Ah, the smell of innocent blood.' : buffer);
+end-proc;
+
+
+dcl-proc test_getWithJsonAccept export;
+    dcl-s headers pointer;
+
+    headers = iv_buildList(
+        'accept' : 'application/json'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/book?q=vampire%20lestat' : headers);
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    aEqual(book : buffer);
+
+    on-exit;
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_getResponeHttpHeader export;
+    dcl-s headers pointer;
+
+    headers = iv_buildList(
+        'accept' : 'application/json'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/book?q=vampire%20lestat' : headers);
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    aEqual('358' : iv_getHeader(httpClient : 'IL_BOOKS_COUNT'));
+
+    on-exit;
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_getWithCustomAccept export;
+    dcl-s headers pointer;
+
+    headers = iv_buildList(
+        'accept' : 'application/vnd.rpgnextgen.isbn'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/book?q=vampire%20lestat' : headers);
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    aEqual('0345419642' : buffer);
+
+    on-exit;
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_getEmptySearchResult export;
+    dcl-s headers pointer;
+
+    headers = iv_buildList(
+        'accept' : 'application/json'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/book?q=arman' : headers);
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    aEqual(BRACKET_OPEN + BRACKET_CLOSE : buffer);
+
+    on-exit;
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_delete export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'DELETE' : baseUrl + '/book/123');
+    iEqual(IV_HTTP_NO_CONTENT : iv_getStatus(httpClient));
+    iEqual(0 : %len(buffer));
+end-proc;
+
+
+dcl-proc test_patchAccepted export;
+    dcl-s headers pointer;
+    dcl-s messageBody varchar(1000:4) ccsid(1208);
+    dcl-s json pointer;
+
+    messageBody = '128';
+    iv_setRequestDataBuffer(httpClient : %addr(messageBody) : %size(messageBody) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    headers = iv_buildList(
+        'Content-Type' : 'text/plain'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'PATCH' : baseUrl + '/book/978-0345419644/rating' : headers);
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    
+    json = jx_parseStringCcsid(%addr(buffer : *data) : 1208);
+    iEqual(128 : jx_getInt(json : 'rating'));
+
+    on-exit;
+        iv_freeList(headers);
+        jx_close(json);
+end-proc;
+
+
+dcl-proc test_patchPathParameterValidation export;
+    dcl-s headers pointer;
+    dcl-s messageBody varchar(1000:4) ccsid(1208);
+    dcl-s json pointer;
+
+    messageBody = '128';
+    iv_setRequestDataBuffer(httpClient : %addr(messageBody) : %size(messageBody) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    headers = iv_buildList(
+        'Content-Type' : 'text/plain'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'PATCH' : baseUrl + '/book/978-0345419644-invalid/rating' : headers);
+    iEqual(IV_HTTP_BAD_REQUEST : iv_getStatus(httpClient));
+
+    on-exit;
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_patchNotFound export;
+    dcl-s headers pointer;
+    dcl-s messageBody varchar(1000:4) ccsid(1208);
+    dcl-s json pointer;
+
+    messageBody = '128';
+    iv_setRequestDataBuffer(httpClient : %addr(messageBody) : %size(messageBody) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    headers = iv_buildList(
+        'Content-Type' : 'text/plain'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'PATCH' : baseUrl + '/book/978-0345419646/rating' : headers);
+    iEqual(IV_HTTP_NOT_FOUND : iv_getStatus(httpClient));
+
+    on-exit;
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_head export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'HEAD' : baseUrl + '/book/978-0345419644');
+    iEqual(IV_HTTP_NO_CONTENT : iv_getStatus(httpClient));
+    assert(%len(buffer) = 0 : 'Message body should be ignored on HEAD request.');
+end-proc;
+
+
+dcl-proc test_headNotFound export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'HEAD' : baseUrl + '/book/978-0345419690');
+    iEqual(IV_HTTP_NOT_FOUND : iv_getStatus(httpClient));
+    assert(%len(buffer) = 0 : 'Message body should be ignored on HEAD request.');
+end-proc;
+
+
+dcl-proc test_headInvalidPathParameter export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'HEAD' : baseUrl + '/book/978-034541964xx');
+    iEqual(IV_HTTP_BAD_REQUEST : iv_getStatus(httpClient));
+    assert(%len(buffer) = 0 : 'Message body should be ignored on HEAD request.');
+end-proc;
+
+
+dcl-proc test_options export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'OPTIONS' : baseUrl + '/book');
+    iEqual(IV_HTTP_NO_CONTENT : iv_getStatus(httpClient));
+    aEqual('GET,POST' : iv_getHeader(httpClient : 'Allow'));
+end-proc;
+
+
+dcl-proc test_post export;
+    dcl-s messageBody varchar(1000:4) ccsid(1208);
+    dcl-s json pointer;
+    dcl-s headers pointer;
+
+    messageBody = CURLY_OPEN;
+    messageBody += '"title": "The Queen of the Damned", +
+		"subtitle": "Vampire Chronicles Book 2", +
+		"publisher": "Random House Publishing Group", +
+		"language": "english", +
+		"format": "tradepaperback", +
+		"isbn": "0345419626", +
+		"isbn13": "978-0345419620", +
+		"relaseDate": "1997-11-29"';
+    messageBody += CURLY_CLOSE;
+    iv_setRequestDataBuffer(httpClient : %addr(messageBody) : %size(messageBody) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    headers = iv_buildList(
+        'Content-Type' : 'application/json' :
+        'Accept' : 'application/json'
+    );
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'POST' : baseUrl + '/book' : headers);
+    iEqual(IV_HTTP_CREATED : iv_getStatus(httpClient));
+
+    json = jx_parseStringCcsid(%addr(buffer : *data) : 1208);
+    aEqual('0345419626' : jx_getStr(json : 'isbn'));
+    iEqual(359 : jx_getInt(json : 'id'));
+    assert(jx_isNull(json : 'rating') : 'There should not be a rating on a new book.');
+
+    on-exit;
+        jx_close(json);
+        iv_freeList(headers);
+end-proc;
+
+
+dcl-proc test_routeNotFound export;
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/not_valid_route');
+    iEqual(IV_HTTP_NOT_FOUND : iv_getStatus(httpClient));
+end-proc;

--- a/itests/templates.rpginc
+++ b/itests/templates.rpginc
@@ -1,0 +1,228 @@
+      /if defined(templates)
+      /eof
+      /endif
+      /define templates
+      //
+      // RPGUnit Data Templates.
+      //
+
+     D TEST_PREFIX     c                   const('TEST')
+
+     D TSTPRC_ALL      c                   '*ALL'
+
+     D ORDER_API       c                   '*API'
+     D ORDER_REVERSE   c                   '*REVERSE'
+
+     D DETAIL_BASIC    c                   '*BASIC'
+     D DETAIL_ALL      c                   '*ALL'
+
+     D OUTPUT_NONE     c                   '*NONE'
+     D OUTPUT_ERROR    c                   '*ERROR'
+     D OUTPUT_ALLWAYS  c                   '*ALLWAYS'
+
+     D RCLRSC_NO       c                   '*NO'
+     D RCLRSC_ALWAYS   c                   '*ALWAYS'
+     D RCLRSC_ONCE     c                   '*ONCE'
+
+       // Source member types
+     D MBR_RPGLE       c                   const('RPGLE')
+     D MBR_SQLRPGLE    c                   const('SQLRPGLE')
+     D PARM_DBGVIEW    c                   const('DBGVIEW')
+
+     D order_t         s             10a   template
+     D detail_t        s             10a   template
+     D output_t        s             10a   template
+     D rclrsc_t        s             10a   template
+
+     D MAX_NUM_LIB     c                   250
+
+     D LibL_t          ds                  template
+     D  numE                   1      2i 0
+     D  lib                    3   2502a   dim(MAX_NUM_LIB)
+
+     D LiblData_t      ds                  qualified template
+     D  curLib                 1     10a
+     D  libL                               likeds(LibL_t)
+
+       // ILE Activation Mark.
+     D ActMark_t       s             10i 0 template
+
+       // Empty Assertion Failure Event of version 1.
+     D EMPTY_ASSERT_FAIL_EVT...
+     D                 ds                  likeds(AssertFailEvt_t) inz
+
+     D EMPTY_ASSERT_FAIL_EVT_LONG...
+     D                 ds                  likeds(AssertFailEvtLong_t) inz
+
+       // Assertion Failure Event.
+     D AssertFailEvtLong_t...
+     D                 ds                  qualified template
+     D  msg                                like(msgText_t)
+     D  callStk                            likeds(CallStk_t)
+
+       // Assertion Failure Event of version 1
+     D assertFailEvt_t...
+     D                 ds                  qualified template
+     D  msg                         256a   varying
+     D  callStk                            likeds(CallStk_t)
+
+       // Call Stack.
+     D CallStk_t       ds                  qualified template
+     D  numE                         10i 0
+     D  entry                              likeds(CallStkEnt_t)
+     D                                     Dim(MAX_CALL_STK_SIZE)
+
+       // Call Stack Entry.
+     D CallStkEnt_t    ds                  qualified template
+     D  level                        10i 0
+     D  sender                             likeds(MsgSender_t)
+
+       // Program Message.
+     D Msg_t           ds                  qualified template
+     D  id                            7a
+     D  txt                                like(msgText_t)
+     D  rplData                     256a   varying
+     D  sender                             likeds(MsgSender_t)
+
+       // Sender of a program message
+     D MsgSender_t     ds                  qualified template
+     D  qPgm                               likeds(Object_t)
+     D  qMod                               likeds(Object_t)
+     D  procNm                             like(ProcNm_t)
+     D  specNb                       10a
+
+     D MsgInfo_t       ds                  qualified template
+     D  id                            7a
+     D  txt                         256a   varying
+     D  pgm                          10a
+     D  mod                          10a
+     D  proc                        256a   varying
+     D  specNb                       10a
+     
+       // Object qualified Name.
+     D Object_t        ds                  qualified template
+     D  nm                           10a
+     D  lib                          10a
+
+       // Spooled file qualified Name.
+     D SplF_t          ds                  qualified template
+     D  system                       10a
+     D  nm                           10a
+     D  nbr                          10i 0
+     D  job                                likeds(Job_t)
+
+       // Job qualified Name.
+     D Job_t           ds                  qualified template
+     D  name                         10A
+     D  user                         10A
+     D  nbr                           6A
+
+       // Named callable procedure.
+     D Proc_t          ds                  qualified template
+     D  procNm                             like(ProcNm_t)
+     D  procPtr                        *   procptr
+
+     D ProcNmList_t    ds                  qualified template
+     D  handle                         *
+     D  cnt                            *   procptr
+     D  getNm                          *   procptr
+     D  goToNext                       *   procptr
+
+     D ProcNm_t        s            256a   varying template
+
+     D ProcNms_t       ds                  qualified template
+     D  numE                          5i 0
+     D  name                               like(ProcNm_t) Dim(250)
+
+       // qualified Job Name.
+     D QlfJobNm_t      ds                  qualified template
+     D  jobNm                        10a
+     D  usrNm                        10a
+     D  jobNb                         6a
+
+     D TestResult_t    ds                  qualified template
+     D  outcome                       1a
+     D  details
+     D  failure                            likeds(AssertFailEvtLong_t)
+     D                                     Overlay(details)
+     D  error                              likeds(Msg_t)
+     D                                     Overlay(details)
+     D  testName                           like(ProcNm_t)
+     D  execTime                     20i 0
+     D  srcFile                      10a
+     D  srcLib                       10a
+     D  srcMbr                       10a
+     D  assertCnt                    10i 0
+
+     D TestSuite_t     ds                  qualified template
+     D  setUpSuite                         likeds(Proc_t)
+     D  setUp                              likeds(Proc_t)
+     D  testCasesCnt                 10i 0
+     D  testList                       *
+     D  tearDown                           likeds(Proc_t)
+     D  teardownSuite                      likeds(Proc_t)
+     D  testResults                    *
+
+       // User profile name.
+     D UsrNm_t         s             10a   template
+
+       // Object description
+     D Text_t          s             50a   varying template
+
+       // String value (must be greater than COMPILEOPT)
+     D String_t...
+     D                 s           5120a   varying template
+
+       // Value of a line of the log.
+     D Line_t          s            256a   varying template
+
+       // Message replacement data or message text.
+     D msgText_t       s           1024a   varying template
+
+       // Full qualified source member.
+     D SrcMbr_t        ds                  qualified template
+     D  file                         10a
+     D  lib                          10a
+     D  mbr                          10a
+
+     D MAX_CALL_STK_SIZE...
+     D                 c                   const(64)
+     D CALL_STACK_INCOMPLETE...
+     D                 c                   const('*INCOMPLETE')
+
+       // TestResult_t.outcome can have three values.
+     D TEST_CASE_SUCCESS...
+     D                 c                   const('S')
+     D TEST_CASE_FAILURE...
+     D                 c                   const('F')
+     D TEST_CASE_ERROR...
+     D                 c                   const('E')
+
+     D QUOTE           c                   const('''')
+
+
+      // A sized array of OS400 objects.
+     D ObjectArray_t   ds                  based(template) qualified
+     D  size                          5i 0
+     D  object                             Dim(51) likeds(Object_t)
+
+       // A sized list of options.
+     D Options_t       ds                  based(template) qualified
+     D  size                          5i 0
+     D  option                       10a   Dim(25)
+
+     D HeadToken_t     s             10a   based(template)
+     D DbgView_t       s             10a   based(template)
+     D Export_t        s             10a   based(template)
+     D ActivationGroup_t...
+     D                 s             10a   based(template)
+
+     D Cmd_t           s           8192a   based(template) varying
+     D SerializedArray_t...
+     D                 s           2048a   based(template) varying
+     D SerializedObject_t...
+     D                 s             21a   based(template) varying
+     D SerializedOptions_t...
+     D                 s            512a   based(template) varying
+     D SerializedString_t...
+     D                 s           5136a   based(template) varying

--- a/src/api.c
+++ b/src/api.c
@@ -321,7 +321,7 @@ void il_addPlugin (PCONFIG pConfig, SERVLET servlet, PLUGINTYPE pluginType)
         }
         plugin.servlet = servlet;
         plugin.pluginType = IL_PREREQUEST;
-        sList_push (pConfig->pluginPreRequest   , sizeof(PLUGIN), &plugin, false);
+        sList_push (pConfig->pluginPreRequest, sizeof(PLUGIN), &plugin, false);
     }
     if (pluginType & IL_POSTRESPONSE) {
         if (pConfig->pluginPostResponse == NULL) {
@@ -329,7 +329,7 @@ void il_addPlugin (PCONFIG pConfig, SERVLET servlet, PLUGINTYPE pluginType)
         }
         plugin.servlet = servlet;
         plugin.pluginType = IL_POSTRESPONSE;
-        sList_push (pConfig->pluginPostResponse , sizeof(PLUGIN), &plugin, false);
+        sList_push (pConfig->pluginPostResponse, sizeof(PLUGIN), &plugin, false);
     }
 }
 /* --------------------------------------------------------------------------- *\
@@ -355,10 +355,11 @@ PVOID il_getThreadMem  (PREQUEST pRequest)
 {
     return pRequest->threadMem;
 }
+
 static parserRouting (PROUTING pRouting , PUCHAR finalExpr , PUCHAR routeReg) 
 {
     pRouting -> parmNumbers =0;
-    // pickup parameter and replace the paramter name with regex for capture groupe
+    // pickup parameter and replace the paramter name with regex for capture group
     while (*routeReg) {
         if (*routeReg == '{') {
             PUCHAR end = strchr(++routeReg , '}');
@@ -440,4 +441,14 @@ void il_addRoute (PCONFIG pConfig, SERVLET servlet, ROUTETYPE routeType , PVARCH
     }
 
     sList_push (pConfig->router , sizeof(ROUTING), &routing, false);
+}
+
+void il_setKeyfile(PCONFIG config, PVARCHAR256 keyfilePath , PVARCHAR64 keyfilePassword) {
+    PNPMPARMLISTADDRP pParms = _NPMPARMLISTADDR();
+
+    config->certificateFile = *keyfilePath;
+    
+    if (pParms->OpDescList->NbrOfParms >= 3) {
+        config->certificatePassword = *keyfilePassword;
+    }
 }

--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -1154,8 +1154,6 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
 
     setCallbacks (pConfig);
 
-    // tInitSSL(pConfig);
-
     // Infinit loop
     for (;;) {
         pthread_t  pServerThread;
@@ -1166,7 +1164,7 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
         int clientSize;
         int errcde;
 
-        if(pConfig->isWorker == 0x40) pConfig->isWorker = false;
+        if(pConfig->isWorker == 0x40 || (unsigned char)pConfig->isWorker == 0xF0) pConfig->isWorker = false;
 
         // Initialize connection
         if(!pConfig->isWorker) {

--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -32,6 +32,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <gskssl.h>
 #include <ssl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -60,10 +61,15 @@
 BOOL (*receiveHeader)  (PREQUEST pRequest);
 BOOL shutdownFlag = false;
 
+BOOL isSecure(PCONFIG config);
+void log_gskit_error(const char * msg, int rc);
+int setupGskitEnvironment(PCONFIG pConfig);
+int setupSecureSocket(PCONFIG pConfig, int clientSocket);
+
 VARCHAR256 il_getCallingProgramPath();
 
 /* --------------------------------------------------------------------------- */
-void prepareResponse  (PRESPONSE pResponse)
+void prepareResponse (PRESPONSE pResponse)
 {
     // if not put yet
     if (pResponse->firstWrite) {
@@ -76,6 +82,7 @@ void prepareResponse  (PRESPONSE pResponse)
 void putChunkEnd (PRESPONSE pResponse)
 {
     int     rc;
+    int     bytesSent = 0;
     LONG    lenleni;
     UCHAR   lenbuf [32];
 
@@ -88,12 +95,22 @@ void putChunkEnd (PRESPONSE pResponse)
 
     lenleni = sprintf (lenbuf , "0\r\n\r\n" );  // end of chunks
     meme2a(lenbuf,lenbuf, lenleni);
-    rc = write(pResponse->pConfig->clientSocket,lenbuf, lenleni);
+
+    if (isSecure(pResponse->pConfig)) {
+        rc = gsk_secure_soc_write(pResponse->pConfig->sessionHandle, lenbuf, lenleni, &bytesSent);
+        if (rc != GSK_OK) {
+            il_joblog("Error on writing chunk end to socket. GSKit error code: %d", rc);
+        }
+    }
+    else {
+        rc = write(pResponse->pConfig->clientSocket, lenbuf, lenleni);
+    }
 }
 /* --------------------------------------------------------------------------- */
 void putChunk (PRESPONSE pResponse, PUCHAR buf, LONG len)
 {
     int rc;
+    int bytesSent = 0;
     LONG   lenleni;
     PUCHAR tempBuf;
     PUCHAR wrkBuf;
@@ -123,7 +140,17 @@ void putChunk (PRESPONSE pResponse, PUCHAR buf, LONG len)
 
     *(wrkBuf++) =  0x0d;
     *(wrkBuf++) =  0x0a;
-    rc = write(pResponse->pConfig->clientSocket, tempBuf , wrkBuf - tempBuf);
+
+    if (isSecure(pResponse->pConfig)) {
+        rc = gsk_secure_soc_write(pResponse->pConfig->sessionHandle, tempBuf, wrkBuf - tempBuf, &bytesSent);
+        if (rc != GSK_OK) {
+            il_joblog("Error on writing chunk to socket. GSKit error code: %d", rc);
+        }
+    }
+    else {
+        rc = write(pResponse->pConfig->clientSocket, tempBuf , wrkBuf - tempBuf);
+    }
+
     memFree (&tempBuf);
 
 }
@@ -131,7 +158,8 @@ void putChunk (PRESPONSE pResponse, PUCHAR buf, LONG len)
 void putChunkXlate (PRESPONSE pResponse, PUCHAR buf, LONG len)
 {
     int rc;
-    LONG   lenleni;
+    int bytesSent = 0;
+    LONG lenleni;
     int outlen = len * 4;
     UCHAR lenBuf [16];
     PUCHAR tempBuf;
@@ -156,8 +184,7 @@ void putChunkXlate (PRESPONSE pResponse, PUCHAR buf, LONG len)
 
     totalWriteLen = wrkBuf - tempBuf;
 
-    if (pResponse->pConfig->protocol == PROT_FASTCGI
-    ||  pResponse->pConfig->protocol == PROT_SECFASTCGI) {
+    if (pResponse->pConfig->protocol == PROT_FASTCGI || pResponse->pConfig->protocol == PROT_SECFASTCGI) {
         rc = FCGX_PutStr( tempBuf , totalWriteLen , pResponse->pConfig->fcgi.out);
         memFree (&totBuf);
         return;
@@ -171,9 +198,18 @@ void putChunkXlate (PRESPONSE pResponse, PUCHAR buf, LONG len)
     *(wrkBuf++) =  0x0d;
     *(wrkBuf++) =  0x0a;
     totalWriteLen = wrkBuf - tempBuf;
-    rc = write(pResponse->pConfig->clientSocket, tempBuf , totalWriteLen);
-    memFree (&totBuf);
 
+    if (isSecure(pResponse->pConfig)) {
+        rc = gsk_secure_soc_write(pResponse->pConfig->sessionHandle, tempBuf, totalWriteLen, &bytesSent);
+        if (rc != GSK_OK) {
+            il_joblog("Error on writing chunk (xlate) to socket. GSKit error code: %d", rc);
+        }
+    }
+    else {
+        rc = write(pResponse->pConfig->clientSocket, tempBuf , totalWriteLen);
+    }
+
+    memFree (&totBuf);
 }
 /* --------------------------------------------------------------------------- */
 /*  Sun, 06 Nov 1994 08:49:37 GMT    ; IMF-fixdate */
@@ -206,6 +242,7 @@ void putHeader (PRESPONSE pResponse)
     const int HEADER_SIZE = 4096;
 
     size_t rc;
+    int bytesSent = 0;
     UCHAR  header [HEADER_SIZE];
     PUCHAR p = header;
     LONG len;
@@ -250,13 +287,19 @@ void putHeader (PRESPONSE pResponse)
     len = p - header;
     meme2a( header , header , len);
 
-    if (pResponse->pConfig->protocol == PROT_FASTCGI
-    ||  pResponse->pConfig->protocol == PROT_SECFASTCGI) {
+    if (pResponse->pConfig->protocol == PROT_FASTCGI || pResponse->pConfig->protocol == PROT_SECFASTCGI) {
         rc = FCGX_PutStr( header , len , pResponse->pConfig->fcgi.out);
     } else {
-        rc = write(pResponse->pConfig->clientSocket, header , len);
+        if (isSecure(pResponse->pConfig)) {
+            rc = gsk_secure_soc_write(pResponse->pConfig->sessionHandle, header, len, &bytesSent);
+            if (rc != GSK_OK) {
+                il_joblog("Error on writing chunk (xlate) to socket. GSKit error code: %d", rc);
+            }
+        }
+        else {
+            rc = write(pResponse->pConfig->clientSocket, header , len);
+        }
     }
-
 }
 /* ---------------------------------------------------------------------------
    Split the url at "?" into resource, and queryString
@@ -494,16 +537,17 @@ BOOL lookForHeaders ( PREQUEST pRequest, PUCHAR buf , ULONG bufLen)
 /* --------------------------------------------------------------------------- */
 static BOOL receivePayload (PREQUEST pRequest)
 {
-    PUCHAR buf = memAlloc (pRequest->contentLength +1); // Add a zero terniation
+    PUCHAR buf = memAlloc (pRequest->contentLength +1); // Add a null termination character
     PUCHAR bufwin , end;
-    LONG   rc;
+    LONG rc;
+    int bytes_received;
 
     // What is already receved:
     memcpy ( buf , pRequest->content.String , pRequest->content.Length);
     bufwin = buf + pRequest->content.Length;
 
     // Build up the previous and the rest
-    buf [pRequest->contentLength] = '\0';  // Enshure It will always be a zeroterminted string if used that way
+    buf [pRequest->contentLength] = '\0';  // Ensure it will always be a null terminated string if used that way
     pRequest->content.String = buf;
     pRequest->content.Length = pRequest->contentLength;
 
@@ -514,11 +558,27 @@ static BOOL receivePayload (PREQUEST pRequest)
             return true;
         }
 
-        rc = read(pRequest->pConfig->clientSocket , bufwin , end - bufwin);
-        if (rc <= 0) {
-            return true;
+        if (isSecure(pRequest->pConfig)) {
+            rc = gsk_secure_soc_read(pRequest->pConfig->sessionHandle, bufwin, end - bufwin, &bytes_received);
+            if (rc != GSK_OK) {
+                il_joblog("Error on reading data from socket. GSKit error code: %d", rc);
+                return false;
+            }
+
+            if (bytes_received == 0) return true;
+
+            bufwin += bytes_received;
+        } else {
+            rc = read(pRequest->pConfig->clientSocket, bufwin, end - bufwin);
+            if (rc < 0) {
+                il_joblog("Error on reading data from socket: Error code: %d", errno);
+                return false;
+            } else if (rc == 0) {
+                return true;
+            } else {
+                bufwin += rc;
+            }
         }
-        bufwin += rc;
     }
 
     return false;
@@ -531,6 +591,7 @@ static BOOL receiveHeaderHTTP (PREQUEST pRequest)
     PUCHAR bufWin = buf;
     ULONG  bufLen = 0;
     LONG   rc;
+    int bytes_received;
     BOOL   isLookingForHeaders = true;
 
     // Load the complete request data
@@ -540,14 +601,25 @@ static BOOL receiveHeaderHTTP (PREQUEST pRequest)
             memFree(&buf);
             return true;
         }
-        rc = read(pRequest->pConfig->clientSocket , bufWin , SOCMAXREAD - bufLen);
-        if (rc <= 0) {
-            memFree(&buf);
-            return true;
+
+        if (isSecure(pRequest->pConfig)) {
+            rc = gsk_secure_soc_read(pRequest->pConfig->sessionHandle, bufWin, SOCMAXREAD - bufLen, &bytes_received);
+            if (rc != GSK_OK) {
+                il_joblog("Error on reading data from socket. GSKit error code: %d", rc);
+                return false;
+            } else if (bytes_received == 0) return true;
+        } else {
+            rc = read(pRequest->pConfig->clientSocket , bufWin , SOCMAXREAD - bufLen);
+            if (rc <= 0) {
+                memFree(&buf);
+                return true;
+            }
+
+            bytes_received = rc;
         }
 
-        bufLen += rc;
-        bufWin += rc;
+        bufLen += bytes_received;
+        bufWin += bytes_received;
         if (isLookingForHeaders) {
             if (lookForHeaders ( pRequest , buf, bufLen)) {
                 if (pRequest->contentLength) {
@@ -797,6 +869,11 @@ static void * serverThread (PINSTANCE pInstance)
         // Clean up this roundtrip 
         cleanupTransaction (&request , &response);
     }
+
+    if (isSecure(&(pInstance->config))) {
+        gsk_secure_soc_close(&(pInstance->config.sessionHandle));
+    }
+
     close(response.pConfig->clientSocket);
     if(! pInstance->config.isWorker) 
     {
@@ -862,6 +939,16 @@ static BOOL getSocket(PCONFIG pConfig)
 
     UCHAR interface  [32];
     vc2strcpy(interface , &pConfig->interface);
+
+    if (isSecure(pConfig)) {
+        rc = setupGskitEnvironment(pConfig);
+        if (rc == 0) {
+            il_joblog("Using HTTPS");
+        } else {
+            il_joblog("Error setting up GSKit environment. Error code: %d.", rc);
+            return false;
+        }
+    }
 
     // Get a socket descriptor
     if ((pConfig->mainSocket = socket(AF_INET, SOCK_STREAM, 0)) < 0)  {
@@ -937,7 +1024,7 @@ int socketWait (int sd , int sec)
     FD_SET(sd,&fd);
     rc = select(sd+1,&fd,NULL,NULL,&timeout);
     if (rc < 0) {
-        il_joblog ("select() failed :%s\r\n", strerror(errno));
+        il_joblog ("select() failed: %s", strerror(errno));
     }
     return rc;
 }
@@ -1074,8 +1161,6 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
         exit(3);
     }
 
-    // tInitSSL(pConfig);
-
     // Infinit loop
     for (;;) {
         pthread_t  pServerThread;
@@ -1131,6 +1216,11 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
             }
         }
 
+        if (isSecure(pConfig) && setupSecureSocket(pConfig, clientSocket) != 0) {
+            il_joblog("Error setting up secure socket");
+            continue;
+        }
+
         // virker ikke:    sprintf(RemoteIp   , "%s" , inet_ntoa(client.sin_addr));
         pConfig->rmtTcpIp = client.sin_addr.s_addr;
         FormatIp(pConfig->rmtHost , client.sin_addr.s_addr);
@@ -1180,3 +1270,91 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
     }
 }
 
+BOOL isSecure(PCONFIG config) {
+    BOOL secured = config->certificateFile.Length > 0;
+    return secured;
+}
+
+void log_gskit_error(const char * msg, int rc) {
+    il_joblog("%s failed with rc=%d", msg, rc);
+}
+
+int setupGskitEnvironment(PCONFIG pConfig) {
+    int rc;
+
+    // Create GSKit environment
+    rc = gsk_environment_open(&(pConfig->envHandle));
+    if (rc != GSK_OK) {
+        il_joblog("GSKit open env failed. Error id: %d", rc);
+        return -1;
+    }
+
+    // Set key database file
+    rc = gsk_attribute_set_buffer(pConfig->envHandle, GSK_KEYRING_FILE, pConfig->certificateFile.String, pConfig->certificateFile.Length);
+    if (rc != GSK_OK) {
+        log_gskit_error("gsk_attribute_set_buffer GSK_KEYRING_FILE", rc);
+        return -1;
+    }
+
+    // Set key database password
+    rc = gsk_attribute_set_buffer(pConfig->envHandle, GSK_KEYRING_PW, pConfig->certificatePassword.String, pConfig->certificatePassword.Length);
+    if (rc != GSK_OK) {
+        log_gskit_error("gsk_attribute_set_buffer GSK_KEYRING_PW", rc);
+        return -1;
+    }
+
+    // TODO define which TLS versions should be used
+    gsk_attribute_set_enum(pConfig->envHandle, GSK_PROTOCOL_TLSV12, GSK_TRUE);
+    if (rc != GSK_OK) {
+        log_gskit_error("gsk_attribute_set_enum TLS 1.2", rc);
+        return -1;
+    }
+    gsk_attribute_set_enum(pConfig->envHandle, GSK_PROTOCOL_TLSV13, GSK_TRUE);
+    if (rc != GSK_OK) {
+        log_gskit_error("gsk_attribute_set_enum TLS 1.3", rc);
+        return -1;
+    }
+
+    // Initialize the environment
+    rc = gsk_environment_init(pConfig->envHandle);
+    if (rc != GSK_OK) {
+        log_gskit_error("gsk_environment_init", rc);
+        return -1;
+    }
+
+    return 0;
+}
+
+int setupSecureSocket(PCONFIG pConfig, int clientSocket) {
+     int rc;
+
+     // Create secure socket handle
+     rc = gsk_secure_soc_open(pConfig->envHandle, &(pConfig->sessionHandle));
+     if (rc != GSK_OK) {
+         log_gskit_error("gsk_secure_soc_open", rc);
+         return -1;
+     }
+
+     // Associate socket with SSL handle
+     rc = gsk_attribute_set_numeric_value(pConfig->sessionHandle, GSK_FD, clientSocket);
+     if (rc != GSK_OK) {
+         log_gskit_error("gsk_attribute_set_numeric_value GSK_FD", rc);
+         return -1;
+     }
+
+     // Set as server socket
+     rc = gsk_attribute_set_enum(pConfig->sessionHandle, GSK_SESSION_TYPE, GSK_SERVER_SESSION);
+     if (rc != GSK_OK) {
+         log_gskit_error("gsk_attribute_set_enum GSK_SESSION_TYPE", rc);
+         return -1;
+     }
+
+     // Initialize secure session
+     rc = gsk_secure_soc_init(pConfig->sessionHandle);
+     if (rc != GSK_OK) {
+         log_gskit_error("gsk_secure_soc_init", rc);
+         return -1;
+     }
+
+     return 0;
+}

--- a/src/makefile
+++ b/src/makefile
@@ -10,7 +10,7 @@
 # (make clean).
 BIN_LIB=ILEASTIC
 TARGET_RLS=*CURRENT
-OUTPUT=*PRINT
+OUTPUT=*NONE
 OS_VERSION=$(shell echo "$(uname -v)$(uname -r)")
 HAS_TGTCCSID=$(shell if [ $(OS_VERSION) -ge 74 ]; then echo yes; else echo no; fi)
 ifeq ($(HAS_TGTCCSID),yes)


### PR DESCRIPTION
Added optional TLS support, #26 . Non TLS ILEastic works as before. Nothing changed. To use TLS the certificate store and optionally a password needs to be set in the config data structure. There is also convenience function for setting the cert store and pass, `il_setKeyfile` . 

To test this I have added an integration test suite which tests the most common use cases. The test suite can be execute with and without TLS, see `itests/README.md` . It uses ILEvator as a HTTP client. So ILEvator needs to be installed to execute the test suite and also RPGUnit.

There is a little readme file on how to setup the certificate store, see `TLS.md`.