### PR TITLE
Added support for querying server certificate details during runtime

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,13 +2,10 @@
     "files.associations": {
         "*.rpginc": "rpgle",
         "*.rpgmod": "rpgle",
+        "*.rpgle": "rpgle",
         "*.dmd": "json",
         "*.widget": "javascript",
-        "strutil.h": "c",
-        "xlate.h": "c",
-        "sndpgmmsg.h": "c",
-        "ostypes.h": "c",
-        "sysdef.h": "c"
+        "*.h": "c"
     },
     "typescript.tsc.autoDetect": "off"
 }

--- a/TLS.md
+++ b/TLS.md
@@ -58,3 +58,33 @@ Test with curl:
 ```
 curl -v --cacert server.pub --url https://localhost:35800
 ```
+
+
+## Certificate Information
+
+Information about the used server certificate can be queried during runtime. The data is available
+via the thread local storage which is a noxDB graph and can be queried with the noxDB API, see 
+`il_getThreadMem`.
+
+Example:
+
+```
+dcl-s tls pointer;
+dcl-s value varchar(100);
+
+tls = il_getThreadMem(request);
+value = jx_getStr(tls : '/ileastic/certificate/server/common_name');
+```
+
+The server certificate information is stored at the path `/ileastic/certificate/server`. The 
+certificate values can be accessed via their corresponding keys. The keys are based on the 
+GSKit certificate data ids. The value for `CERT_COMMON_NAME` can be access by the key `common_name`.
+All values are strings.
+
+The certificate is only available if it has been enabled by calling `il_setTlsServerCertEnabled`.
+
+```
+il_setTlsServerCertEnabled(config : IL_TRUE);
+```
+
+For more information and available keys see the GSKit API [gsk_attribute_get_cert_info](https://www.ibm.com/docs/en/i/7.4.0?topic=ssw_ibm_i_74/apis/gsk_attribute_get_cert_info.html).

--- a/headers/ileastic.bnd
+++ b/headers/ileastic.bnd
@@ -35,4 +35,5 @@ STRPGMEXP PGMLVL(*CURRENT) SIGNATURE('ILEastic 1.1.2')
     EXPORT SYMBOL("il_mediatype_isMediaTypeAccepted")
     EXPORT SYMBOL("il_mediatype_parseMediaType")
     EXPORT SYMBOL("il_setKeyfile")
+    EXPORT SYMBOL("il_setTlsServerCertEnabled")
 ENDPGMEXP

--- a/headers/ileastic.rpgle
+++ b/headers/ileastic.rpgle
@@ -366,20 +366,23 @@ dcl-c IL_MEDIA_TYPE_JSON 'application/json';
 ///
 dcl-c IL_MEDIA_TYPE_XML 'application/xml';
 
+dcl-c IL_TRUE 1;
+dcl-c IL_FALSE 0;
 
 ///
 // Configuration
 ///
 dcl-ds il_config qualified template;
-    host                varchar(64);
-    port                int(10);
-    protocol            int(5);
-    certificateFile     varchar(256);
-    certificatePassword varchar(64);
-    workerProgram       varchar(256);
-    isWorker            ind;
-    threadingMode       int(5);
-    filler              char(4096); // required - contains the private internal handlers
+    host                 varchar(64);
+    port                 int(10);
+    protocol             int(5);
+    certificateFile      varchar(256);
+    certificatePassword  varchar(64);
+    workerProgram        varchar(256);
+    isWorker             ind;
+    threadingMode        int(5);
+    tlsServerCertEnabled int(5);
+    filler               char(4096); // required - contains the private internal handlers
 end-ds;
 
 ///
@@ -1061,4 +1064,24 @@ dcl-pr il_setKeyfile extproc(*dclcase);
     config likeds(il_config);
     keyfilePath varchar(256) const;
     keyfilePassword varchar(64) const options(*nopass);
+end-pr;
+
+///
+// Enable Server Certificate Infos in TLS
+//
+// If enabled the available infos about the used server certificate for the TLS
+// connection are copied to the thread local storage avaiable in the request,
+// see il_getThreadMem.
+// <p>
+// The information will be copied to the path /ileastic/certificate/server.
+// The information is only available if the connection uses TLS (HTTPS).
+//
+// @param Configuration
+// @param IL_TRUE = enabled , IL_FALSE = disable (default)
+//
+// @info This setting has no effect if no TLS is used.
+///
+dcl-pr il_setTlsServerCertEnabled extproc(*dclcase);
+    config likeds(il_config);
+    enabled int(5) value;
 end-pr;

--- a/headers/ileastic.rpgle
+++ b/headers/ileastic.rpgle
@@ -381,7 +381,7 @@ dcl-ds il_config qualified template;
     workerProgram        varchar(256);
     isWorker             ind;
     threadingMode        int(5);
-    tlsServerCertEnabled int(5);
+    tlsServerCertEnabled int(3);
     filler               char(4096); // required - contains the private internal handlers
 end-ds;
 

--- a/headers/sysdef.h
+++ b/headers/sysdef.h
@@ -65,7 +65,8 @@ typedef _Packed struct _CONFIG  {
     VARCHAR256  workerProgram;
     BOOL        isWorker;
     THREADING_MODE threadingMode;
-    UCHAR       filler[1024];
+    BOOL        tlsServerCertEnabled;
+    UCHAR       filler[1022];
     // Private:
     int         mainSocket;
     int         clientSocket;

--- a/itests/ilbasics.rpgle
+++ b/itests/ilbasics.rpgle
@@ -80,6 +80,8 @@ dcl-proc main;
         il_setKeyfile(config : keyFilePath : keyFileSecret);
     endif;
 
+    il_setTlsServerCertEnabled(config : IL_TRUE);
+
     il_addRoute(config : %paddr(test_getBookExcerpt) : IL_GET : REGEX_START + '/book/excerpt' + REGEX_END);
     il_addRoute(config : %paddr(test_deleteBook) : IL_DELETE: REGEX_START + '/book/' + CURLY_OPEN + 'isbn' + CURLY_CLOSE + REGEX_END);
     il_addRoute(config : %paddr(test_updateRating) : IL_PATCH : REGEX_START + '/book/' + CURLY_OPEN + 'isbn' + CURLY_CLOSE + '/rating' + REGEX_END);
@@ -87,6 +89,7 @@ dcl-proc main;
     il_addRoute(config : %paddr(test_createBook) : IL_POST : REGEX_START + '/book' + REGEX_END);
     il_addRoute(config : %paddr(test_search) : IL_GET : REGEX_START + '/book' + REGEX_END);
     il_addRoute(config : %paddr(test_bookOptions) : IL_OPTIONS : REGEX_START + '/book' + REGEX_END);
+    il_addRoute(config : %paddr(test_getServerCertInfos) : IL_GET : REGEX_START + '/cert/server' + REGEX_END);
     il_addRoute(config : %paddr(test_notFound));
 
     il_listen (config);
@@ -273,4 +276,22 @@ dcl-proc test_updateRating;
 
     on-exit;
         jx_close(json);
+end-proc;
+
+
+dcl-proc test_getServerCertInfos;
+    dcl-pi *n;
+        request  likeds(IL_REQUEST);
+        response likeds(IL_RESPONSE);
+    end-pi;
+
+    dcl-s tls pointer;
+    dcl-s serverCertInfos pointer;
+
+    tls = il_getThreadMem(request);
+    serverCertInfos = jx_locate(tls : '/ileastic/certificate/server');
+
+    response.status = 200;
+    response.contentType = 'application/json';
+    il_responseWriteStream(response: jx_stream(serverCertInfos));
 end-proc;

--- a/itests/ilbasicst.rpgle
+++ b/itests/ilbasicst.rpgle
@@ -46,14 +46,17 @@ dcl-pr test_headErrorMessageBody end-pr;
 dcl-pr test_options end-pr;
 dcl-pr test_post end-pr;
 dcl-pr test_routeNotFound end-pr;
+dcl-pr test_serverCertificateInfos end-pr;
 
 
 dcl-s httpClient pointer;
 dcl-s keyFilePath varchar(1000);
 dcl-s keyFileSecret varchar(100);
 dcl-s baseUrl varchar(100);
-dcl-s buffer varchar(65000:4) ccsid(1208);
+// dcl-s buffer varchar(65000:4) ccsid(1208);
+dcl-s buffer varchar(200000:4) ccsid(1208);
 dcl-s book varchar(1000);
+dcl-s secured ind;
 
 dcl-proc setup export;
     dcl-s value pointer;
@@ -61,6 +64,7 @@ dcl-proc setup export;
     value = getenv('ILEASTIC_ITEST_KEYFILE_PATH');
     if (value <> *null);
         keyFilePath = %str(value);
+        secured = *on;
     endif;
 
     value = getenv('ILEASTIC_ITEST_KEYFILE_SECRET');
@@ -79,7 +83,6 @@ dcl-proc setup export;
     httpClient = iv_newHttpClient();
     iv_setTimeout(httpClient : 5);
     iv_setRetries(httpClient : 1);
-    iv_setCertificate(httpClient : '/home/mschmidt/cert/rpgnextgen/server.kdb' : 'changeit');
 
     book = BRACKET_OPEN;
     book += CURLY_OPEN;
@@ -356,4 +359,30 @@ dcl-proc test_routeNotFound export;
 
     iv_execute(httpClient : 'GET' : baseUrl + '/not_valid_route');
     iEqual(IV_HTTP_NOT_FOUND : iv_getStatus(httpClient));
+end-proc;
+
+
+dcl-proc test_serverCertificateInfos export;
+    dcl-s json pointer;
+    dcl-s entryValue varchar(1000);
+
+    if (not secured);
+        return;
+    endif;
+
+    clear buffer;
+    iv_setResponseDataBuffer (httpClient : %addr(buffer) : %size(buffer) : IV_VARCHAR4 : IV_CCSID_UTF8);
+
+    iv_execute(httpClient : 'GET' : baseUrl + '/cert/server');
+    iEqual(IV_HTTP_OK : iv_getStatus(httpClient));
+    
+    json = jx_parseStringCcsid(%addr(buffer : *data) : 1208);
+    entryValue = jx_getStr(json : 'common_name');
+    assert(entryValue <> *blank : 'CERT_COMMON_NAME should not be blank/empty');
+
+    entryValue = jx_getStr(json : 'dn_printable');
+    assert(entryValue <> *blank : 'CERT_DN_PRINTABLE should not be blank/empty');
+
+    on-exit;
+        jx_close(json);
 end-proc;

--- a/src/api.c
+++ b/src/api.c
@@ -452,3 +452,7 @@ void il_setKeyfile(PCONFIG config, PVARCHAR256 keyfilePath , PVARCHAR64 keyfileP
         config->certificatePassword = *keyfilePassword;
     }
 }
+
+void il_setTlsServerCertEnabled(PCONFIG config, BOOL enabled) {
+    config->tlsServerCertEnabled = enabled;
+}

--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -816,12 +816,17 @@ static void * serverThread (PINSTANCE pInstance)
     PROUTING matchingRouting;
     BOOL     connected = true; 
     UCHAR    temp [256]; 
+    PVOID serverCertNode;
     
     if(! pInstance->config.isWorker) 
     {
         pthread_detach(pthread_self());
     }   
 
+    if (isSecure(&(pInstance->config)) && pInstance->config.tlsServerCertEnabled) {
+        serverCertNode = jx_NewObject(NULL);
+        addServerCertInfos(&(pInstance->config.envHandle), serverCertNode);
+    }
 
     while (pInstance->config.clientSocket > 0 && connected) {
         memset(&request  , 0, sizeof(REQUEST));
@@ -842,9 +847,6 @@ static void * serverThread (PINSTANCE pInstance)
         
         request.threadMem = (PVOID) jx_NewObject(NULL);
         if (isSecure(&(pInstance->config)) && pInstance->config.tlsServerCertEnabled) {
-            PVOID serverCertNode = jx_NewObject(NULL);
-            addServerCertInfos(&(pInstance->config.envHandle), serverCertNode);
-
             PJXNODE tlsCertNode = jx_GetOrCreateNode(request.threadMem, "/ileastic/certificate");
             jx_NodeMoveInto(tlsCertNode, "server", serverCertNode);
         }

--- a/src/ileastic.c
+++ b/src/ileastic.c
@@ -65,6 +65,7 @@ BOOL isSecure(PCONFIG config);
 void log_gskit_error(const char * msg, int rc);
 int setupGskitEnvironment(PCONFIG pConfig);
 int setupSecureSocket(PCONFIG pConfig, int clientSocket);
+void addServerCertInfos(gsk_handle * sslHandle, void * threadMem);
 
 VARCHAR256 il_getCallingProgramPath();
 
@@ -840,6 +841,13 @@ static void * serverThread (PINSTANCE pInstance)
         pResponse = &response;
         
         request.threadMem = (PVOID) jx_NewObject(NULL);
+        if (isSecure(&(pInstance->config)) && pInstance->config.tlsServerCertEnabled) {
+            PVOID serverCertNode = jx_NewObject(NULL);
+            addServerCertInfos(&(pInstance->config.envHandle), serverCertNode);
+
+            PJXNODE tlsCertNode = jx_GetOrCreateNode(request.threadMem, "/ileastic/certificate");
+            jx_NodeMoveInto(tlsCertNode, "server", serverCertNode);
+        }
 
         #pragma exception_handler(handleServletException, pResponse, _C1_ALL, _C2_MH_ESCAPE, _CTLA_HANDLE)
         matchingRouting = findRoute(request.pConfig, &request);
@@ -1188,7 +1196,6 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
             return ;
         }
 
-
         // accept() the incoming connection request.
         clientSize = sizeof(client);
         if(!pConfig->isWorker) {
@@ -1210,7 +1217,7 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
             close(0);
         }
 
-        if (isSecure(pConfig) && setupSecureSocket(pConfig, clientSocket) != 0) {
+        if (isSecure(pConfig) && setupSecureSocket(pConfig, clientSocket) != 0)  {
             il_joblog("Error setting up secure socket");
             continue;
         }
@@ -1269,6 +1276,194 @@ void il_listen (PCONFIG pConfig, SERVLET servlet)
                 exit(-1);
         }
     }
+}
+
+void addServerCertInfos(gsk_handle * sslHandle, void * serverCertInfos) {
+    // All certificate data is returned in ASCII CCSID 850.
+    PXLATEDESC a2e = XlateXdOpen(850, 0);
+
+    gsk_cert_data_elem *certElements;
+    int certElementCount = 0;
+    int rc;
+    PUCHAR certInfoKey;
+    char certInfoValue[1024];
+
+    rc = gsk_attribute_get_cert_info (
+            *sslHandle,
+            GSK_LOCAL_CERT_INFO,
+            &certElements,
+            &certElementCount);
+
+    if (rc == GSK_OK) {
+        il_joblog("got cert infos: %d", certElementCount);
+
+        // typedef struct gsk_cert_data_elem_t {
+        //     GSK_CERT_DATA_ID cert_data_id;
+        //     char *cert_data_p;
+        //     int cert_data_l;
+        // } gsk_cert_data_elem;
+
+
+        for (int i = 0; i < certElementCount; i++) {
+            rc = XlateXdBuf(a2e , certInfoValue, certElements[i].cert_data_p , certElements[i].cert_data_l);
+            if (rc >= sizeof(certInfoValue)) certInfoValue[1023] = '\0';
+            else if (rc > 0) certInfoValue[rc] = '\0';
+            else certInfoValue[0] = '\0';
+
+            certInfoKey = NULL;
+
+            switch(certElements[i].cert_data_id) {
+                case 601:
+                    certInfoKey = "body_base64";
+                    break;
+                case 602:
+                    certInfoKey = "serial_number";
+                    break;
+                case 610:
+                    certInfoKey = "common_name";
+                    break;
+                case 611:
+                    certInfoKey = "locality";
+                    break;
+                case 612:
+                    certInfoKey = "state_or_province";
+                    break;
+                case 613:
+                    certInfoKey = "country";
+                    break;
+                case 614:
+                    certInfoKey = "org";
+                    break;
+                case 615:
+                    certInfoKey = "org_unit";
+                    break;
+                case 616:
+                    certInfoKey = "dn_printable";
+                    break;
+                case 618:
+                    certInfoKey = "postal_code";
+                    break;
+                case 619:
+                    certInfoKey = "email";
+                    break;
+                case 650:
+                    certInfoKey = "issuer_common_name";
+                    break;
+                case 651:
+                    certInfoKey = "issuer_locality";
+                    break;
+                case 652:
+                    certInfoKey = "issuer_state_or_province";
+                    break;
+                case 653:
+                    certInfoKey = "issuer_country";
+                    break;
+                case 654:
+                    certInfoKey = "issuer_org";
+                    break;
+                case 655:
+                    certInfoKey = "issuer_org_unit";
+                    break;
+                case 656:
+                    certInfoKey = "issuer_dn_printable";
+                    break;
+                case 658:
+                    certInfoKey = "issuer_postal_code";
+                    break;
+                case 659:
+                    certInfoKey = "issuer_email";
+                    break;
+                case 660:
+                    certInfoKey = "version";
+                    break;
+                case 661:
+                    certInfoKey = "signature_algorithm";
+                    break;
+                case 662:
+                    certInfoKey = "valid_from";
+                    break;
+                case 663:
+                    certInfoKey = "valid_to";
+                    break;
+                case 664:
+                    certInfoKey = "public_key_algorithm";
+                    break;
+                case 665:
+                    certInfoKey = "public_key";
+                    break;
+                case 666:
+                    certInfoKey = "public_key_size";
+                    break;
+                case 667:
+                    certInfoKey = "fingerprint_algorithm";
+                    break;
+                case 668:
+                    certInfoKey = "fingerprint";
+                    break;
+                case 669:
+                    certInfoKey = "issuer_uniqueid";
+                    break;
+                case 670:
+                    certInfoKey = "subject_uniqueid";
+                    break;
+                case 671:
+                    certInfoKey = "key_usage";
+                    break;
+                case 672:
+                    certInfoKey = "subject_alternative_name_rfc822name";
+                    break;
+                case 673:
+                    certInfoKey = "subject_alternative_name_dnsname";
+                    break;
+                case 674:
+                    certInfoKey = "subject_alternative_name_directoryname";
+                    break;
+                case 675:
+                    certInfoKey = "subject_alternative_name_uri";
+                    break;
+                case 676:
+                    certInfoKey = "subject_alternative_name_ipaddress";
+                    break;
+                case 677:
+                    certInfoKey = "certificate_policy_policyidentifier";
+                    break;
+                case 678:
+                    certInfoKey = "basic_constraints_ca";
+                    break;
+                case 679:
+                    certInfoKey = "basic_constraints_path_length_constraint";
+                    break;
+                case 680:
+                    certInfoKey = "crl_distribution_points_distributionpointname";
+                    break;
+                case 681:
+                    certInfoKey = "valid_from_ex";
+                    break;
+                case 682:
+                    certInfoKey = "valid_to_ex";
+                    break;
+                case 683:
+                    certInfoKey = "fingerprint_sha1";
+                    break;
+                case 684:
+                    certInfoKey = "fingerprint_sha256";
+                    break;
+                case 685:
+                    certInfoKey = "extendedkeyusage_identifier";
+                    break;
+                case 688:
+                    certInfoKey = "aia_access_location";
+                    break;
+            }
+
+            if (certInfoKey) jx_SetStrByName (serverCertInfos, certInfoKey, certInfoValue);
+        }
+
+    } else {
+        log_gskit_error("gsk_attribute_get_cert_info", rc);
+    }
+
+    XlateXdClose(a2e);
 }
 
 BOOL isSecure(PCONFIG config) {


### PR DESCRIPTION
If TLS is used the server certificate information is stored in the thread local storage under `/ileastic/certificate/server`. The certificate details are fetched by calling `gsk_attribute_get_cert_info`. This can only be done after a TLS handshake has been done.

By default this feature is disabled. It can be enabled by calling `il_setTlsServerCertEnabled`. 

For more documentation see `TLS.md`.